### PR TITLE
fix: Repair CI YAML and de-arm the write-capable workflows, together

### DIFF
--- a/.github/workflows/data-integrity.yml
+++ b/.github/workflows/data-integrity.yml
@@ -1,0 +1,75 @@
+name: Data Integrity
+
+# Read-only assertions about the data and the pipeline. This workflow never
+# writes to the repository and has no write permissions, which is why it is safe
+# to arm on push and pull_request while the other data workflows are de-armed.
+#
+# What it asserts, and why each one is here:
+#
+#   check_workflow_disarm.py   the workflows that can commit stay unable to run
+#                              unattended. A comment saying so is one careless
+#                              edit from gone; this fails a build instead.
+#
+#   check_invariants.py        the claims this repo documents about itself are
+#                              true right now -- manifest checksums, feed counts,
+#                              zone boundaries. Every documented claim that got
+#                              measured during the 2026-07 forward-fill turned
+#                              out to be slightly wrong, so they are asserted
+#                              rather than written down.
+#
+#   project_candidates --check data/serveable/ is a build output, byte-identical
+#                              to a fresh projection. The repo previously lost
+#                              this property for seven months: MANIFEST.json said
+#                              28 events while all_events.json said 1,194,
+#                              because two producers wrote to one zone and
+#                              nothing compared them.
+#
+#   tests/test_*.py            run directly. pytest is in requirements.txt but
+#                              these are standalone runners and both pass without
+#                              it; invoking python directly keeps this job free of
+#                              any pip install, so it cannot break on dependency
+#                              drift.
+#
+# Only PyYAML is installed, for the de-arm guard. Everything else is stdlib.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  integrity:
+    name: Assert data and pipeline invariants
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Write-capable workflows are de-armed
+        run: python scripts/validation/check_workflow_disarm.py
+
+      - name: Repository invariants hold
+        run: python scripts/validation/check_invariants.py
+
+      - name: Serveable zone matches a fresh build
+        run: python scripts/build/project_candidates.py --check
+
+      - name: Dump-space tests
+        run: python tests/test_dump_spaces.py
+
+      - name: Migration tests
+        run: python tests/test_migration.py

--- a/.github/workflows/data-pipeline-automation.yml
+++ b/.github/workflows/data-pipeline-automation.yml
@@ -15,14 +15,34 @@ name: Automated Data Pipeline
 # - Can also be called by other workflows
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'data/raw/**'
-      - 'scripts/transformation/**'
-      - 'scripts/validation/**'
-      - 'config/schemas/**'
+  # DE-ARMED 2026-07-30. Do not restore the push trigger without first settling
+  # which producer is canonical for the serveable zone.
+  #
+  # Stage 2A of this workflow runs scripts/transformation/clean_events.py, whose
+  # output is 28 records where data/serveable/api/timeline_events/all_events.json
+  # holds 1,194. Armed on push to data/raw/**, this workflow would rewrite the
+  # serveable zone and auto-commit the result. Until 2026-07-30 the only thing
+  # preventing that was a YAML syntax error further down this file; repairing the
+  # syntax without removing this trigger would have armed a data-clobbering bot.
+  # Hence the repair and this de-arm landed in the same commit.
+  #
+  # Two independent guards now stand behind this: clean_events.py refuses to run
+  # without --write (exit 2), and data/serveable/ is asserted to be a build output
+  # by scripts/build/project_candidates.py --check.
+  #
+  # Re-arming checklist, all three required:
+  #   1. Single canonical producer for data/serveable/ agreed and documented.
+  #   2. This workflow verified against that producer on a branch, not on main.
+  #   3. scripts/validation/check_invariants.py green in the same run.
+  #
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'data/raw/**'
+  #     - 'scripts/transformation/**'
+  #     - 'scripts/validation/**'
+  #     - 'config/schemas/**'
 
   workflow_dispatch:
     inputs:
@@ -374,26 +394,26 @@ jobs:
           fi
 
           cat > commit_message.txt << EOF
-chore: automated data pipeline run
+          chore: automated data pipeline run
 
-Automated transformation pipeline completed
+          Automated transformation pipeline completed
 
-- Timestamp: ${TIMESTAMP}
-- Total events: ${EVENT_COUNT}
-- Workflow run: ${{ github.run_number }}
-- Triggered by: ${{ github.event_name }}
+          - Timestamp: ${TIMESTAMP}
+          - Total events: ${EVENT_COUNT}
+          - Workflow run: ${{ github.run_number }}
+          - Triggered by: ${{ github.event_name }}
 
-Pipeline stages:
-1. Validation of raw data
-2. Cleaning (deduplication, ASCII conversion)
-3. Enrichment (derived fields, metrics)
-4. Transformation to timeline events
-5. Manifest generation
+          Pipeline stages:
+          1. Validation of raw data
+          2. Cleaning (deduplication, ASCII conversion)
+          3. Enrichment (derived fields, metrics)
+          4. Transformation to timeline events
+          5. Manifest generation
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+          Generated with Claude Code (https://claude.com/claude-code)
 
-Co-Authored-By: GitHub Actions <actions@github.com>
-EOF
+          Co-Authored-By: GitHub Actions <actions@github.com>
+          EOF
 
           git commit -F commit_message.txt
           git push
@@ -412,13 +432,13 @@ EOF
           if [ -f "data/serveable/MANIFEST.json" ]; then
             echo "Dataset summary:"
             python -c "
-import json
-with open('data/serveable/MANIFEST.json') as f:
-    manifest = json.load(f)
-    print(f\"  Total datasets: {manifest['summary']['total_datasets']}\")
-    print(f\"  Total events: {manifest['summary']['total_events']}\")
-    print(f\"  Formats: {', '.join(manifest['summary']['formats'])}\")
-"
+          import json
+          with open('data/serveable/MANIFEST.json') as f:
+              manifest = json.load(f)
+              print(f\"  Total datasets: {manifest['summary']['total_datasets']}\")
+              print(f\"  Total events: {manifest['summary']['total_events']}\")
+              print(f\"  Formats: {', '.join(manifest['summary']['formats'])}\")
+          "
           fi
 
           echo ""

--- a/.github/workflows/documentation-ci.yml
+++ b/.github/workflows/documentation-ci.yml
@@ -192,36 +192,52 @@ jobs:
         
         echo "[PASS] Version increment check completed"
 
-  documentation-publish:
-    runs-on: ubuntu-latest
-    name: Publish Development Notes
-    if: github.ref == 'refs/heads/main'
-    needs: [documentation-quality, version-increment-check]
-    
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Generate Build Timestamp
-      run: |
-        echo "BUILD_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_ENV
-        echo "BUILD_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-    
-    - name: Update Build Info
-      run: |
-        echo "" >> DEVBLOG.md
-        echo "---" >> DEVBLOG.md
-        echo "**Build Info**: $BUILD_TIME | SHA: $BUILD_SHA" >> DEVBLOG.md
-        echo "**CI Status**: All documentation tests passed" >> DEVBLOG.md
-        echo "**Permanent URL**: https://github.com/PipFoweraker/pdoom-data/blob/$BUILD_SHA/DEVBLOG.md" >> DEVBLOG.md
-    
-    - name: Commit Updated Documentation
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add DEVBLOG.md
-        if git diff --staged --quiet; then
-          echo "No documentation changes to commit"
-        else
-          git commit -m "docs: Update build info and permanent links [skip ci]"
-          git push
-        fi
+  # DE-ARMED 2026-07-30. This job is a latent auto-commit bot.
+  #
+  # It appended five lines to DEVBLOG.md with `echo >>` -- never a rewrite -- and
+  # pushed, on every push to main. DEVBLOG.md therefore grows without bound, one
+  # block per merged commit, and concurrent pushes race on it.
+  #
+  # It has never actually run: it `needs` documentation-quality, which fails on
+  # the ASCII gate (20 files of box-drawing and arrows). That makes it a trap of
+  # the same shape as the one in data-pipeline-automation.yml -- an agent told
+  # "fix the failing ASCII check" would, as a side effect, arm this. Recording it
+  # here so the next person meets the comment before the behaviour.
+  #
+  # If build provenance in DEVBLOG.md is still wanted, the fix is a rewritten
+  # marker block (replace between sentinels) rather than an append, and it should
+  # be a release-time action, not a per-push one. That is a call for the owner.
+  #
+  # documentation-publish:
+  #   runs-on: ubuntu-latest
+  #   name: Publish Development Notes
+  #   if: github.ref == 'refs/heads/main'
+  #   needs: [documentation-quality, version-increment-check]
+  #
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #
+  #   - name: Generate Build Timestamp
+  #     run: |
+  #       echo "BUILD_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_ENV
+  #       echo "BUILD_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+  #
+  #   - name: Update Build Info
+  #     run: |
+  #       echo "" >> DEVBLOG.md
+  #       echo "---" >> DEVBLOG.md
+  #       echo "**Build Info**: $BUILD_TIME | SHA: $BUILD_SHA" >> DEVBLOG.md
+  #       echo "**CI Status**: All documentation tests passed" >> DEVBLOG.md
+  #       echo "**Permanent URL**: https://github.com/PipFoweraker/pdoom-data/blob/$BUILD_SHA/DEVBLOG.md" >> DEVBLOG.md
+  #
+  #   - name: Commit Updated Documentation
+  #     run: |
+  #       git config --local user.email "action@github.com"
+  #       git config --local user.name "GitHub Action"
+  #       git add DEVBLOG.md
+  #       if git diff --staged --quiet; then
+  #         echo "No documentation changes to commit"
+  #       else
+  #         git commit -m "docs: Update build info and permanent links [skip ci]"
+  #         git push
+  #       fi

--- a/.github/workflows/weekly-data-refresh.yml
+++ b/.github/workflows/weekly-data-refresh.yml
@@ -16,10 +16,23 @@ name: Weekly Data Refresh
 # - Write permissions for repository
 
 on:
-  schedule:
-    # Run every Monday at 2:00 AM UTC
-    # Cron format: minute hour day-of-month month day-of-week
-    - cron: '0 2 * * 1'
+  # DE-ARMED 2026-07-30, alongside the YAML repair further down this file.
+  #
+  # This workflow extracts from Hugging Face and auto-commits to data/raw/. Until
+  # 2026-07-30 it was inert only because of a YAML syntax error. Restoring the
+  # syntax while leaving the cron armed would have started weekly unattended
+  # writes into the raw zone, which the repo treats as immutable, and would also
+  # have re-triggered data-pipeline-automation.yml via its data/raw/** path
+  # filter. The two workflows form a loop; both triggers came off together.
+  #
+  # Re-arming requires deciding how an automated extractor writes to a zone whose
+  # contract says dumps are immutable and re-runs produce NEW dumps. Manual
+  # dispatch is retained and is the supported path meanwhile.
+  #
+  # schedule:
+  #   # Run every Monday at 2:00 AM UTC
+  #   # Cron format: minute hour day-of-month month day-of-week
+  #   - cron: '0 2 * * 1'
 
   workflow_dispatch:
     # Allow manual triggering from GitHub UI
@@ -69,7 +82,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install datasets huggingface_hub jsonschema jsonlines
-          echo "✓ Dependencies installed"
+          echo "[ok] Dependencies installed"
 
       - name: Display environment info
         run: |
@@ -121,9 +134,9 @@ jobs:
           echo ""
           echo "=================================================="
           if [ $EXIT_CODE -eq 0 ]; then
-            echo "✓ Extraction completed successfully"
+            echo "[ok] Extraction completed successfully"
           else
-            echo "✗ Extraction failed with exit code ${EXIT_CODE}"
+            echo "[FAIL] Extraction failed with exit code ${EXIT_CODE}"
           fi
           echo "=================================================="
 
@@ -143,7 +156,7 @@ jobs:
           LATEST_DUMP=$(ls -td data/raw/alignment_research/dumps/*/ 2>/dev/null | head -n 1)
 
           if [[ -z "$LATEST_DUMP" ]]; then
-            echo "✗ No dump directory found"
+            echo "[FAIL] No dump directory found"
             exit 1
           fi
 
@@ -160,9 +173,9 @@ jobs:
           echo ""
           echo "=================================================="
           if [ $EXIT_CODE -eq 0 ]; then
-            echo "✓ Validation passed"
+            echo "[ok] Validation passed"
           else
-            echo "✗ Validation failed"
+            echo "[FAIL] Validation failed"
           fi
           echo "=================================================="
 
@@ -190,24 +203,24 @@ jobs:
             if [[ -f "${LATEST_DUMP}_metadata.json" ]]; then
               echo "Metadata:"
               python -c "
-import json
-import sys
-with open('${LATEST_DUMP}_metadata.json') as f:
-    meta = json.load(f)
-    print(f\"  Source: {meta.get('source_name')}\" )
-    print(f\"  Extraction date: {meta.get('extraction_date')}\")
-    print(f\"  Extraction type: {meta.get('extraction_type')}\")
-    print(f\"  Record count: {meta.get('record_count')}\")
-    print(f\"  Status: {meta.get('extraction_status')}\")
+          import json
+          import sys
+          with open('${LATEST_DUMP}_metadata.json') as f:
+              meta = json.load(f)
+              print(f\"  Source: {meta.get('source_name')}\" )
+              print(f\"  Extraction date: {meta.get('extraction_date')}\")
+              print(f\"  Extraction type: {meta.get('extraction_type')}\")
+              print(f\"  Record count: {meta.get('record_count')}\")
+              print(f\"  Status: {meta.get('extraction_status')}\")
 
-    stats = meta.get('extraction_statistics', {})
-    if stats:
-        print(f\"  Records fetched: {stats.get('records_fetched')}\")
-        print(f\"  Records filtered: {stats.get('records_filtered')}\")
-        print(f\"  Records written: {stats.get('records_written')}\")
-        print(f\"  Errors: {stats.get('errors_encountered')}\")
-        print(f\"  Duration: {stats.get('duration_seconds', 0):.1f}s\")
-"
+              stats = meta.get('extraction_statistics', {})
+              if stats:
+                  print(f\"  Records fetched: {stats.get('records_fetched')}\")
+                  print(f\"  Records filtered: {stats.get('records_filtered')}\")
+                  print(f\"  Records written: {stats.get('records_written')}\")
+                  print(f\"  Errors: {stats.get('errors_encountered')}\")
+                  print(f\"  Duration: {stats.get('duration_seconds', 0):.1f}s\")
+          "
             fi
 
             echo ""
@@ -279,19 +292,19 @@ with open('${LATEST_DUMP}_metadata.json') as f:
 
           # Create detailed commit message
           cat > commit_message.txt << EOF
-data: weekly alignment research refresh
+          data: weekly alignment research refresh
 
-Automated data refresh from StampyAI Alignment Research Dataset
+          Automated data refresh from StampyAI Alignment Research Dataset
 
-- Timestamp: ${TIMESTAMP}
-- Records: ${RECORD_COUNT}
-- Workflow run: ${{ github.run_number }}
-- Triggered by: ${{ github.event_name }}
+          - Timestamp: ${TIMESTAMP}
+          - Records: ${RECORD_COUNT}
+          - Workflow run: ${{ github.run_number }}
+          - Triggered by: ${{ github.event_name }}
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+          Generated with Claude Code (https://claude.com/claude-code)
 
-Co-Authored-By: GitHub Actions <actions@github.com>
-EOF
+          Co-Authored-By: GitHub Actions <actions@github.com>
+          EOF
 
           # Commit with detailed message
           git commit -F commit_message.txt
@@ -299,12 +312,12 @@ EOF
           # Push changes
           git push
 
-          echo "✓ Changes committed and pushed successfully"
+          echo "[ok] Changes committed and pushed successfully"
 
       - name: No changes to commit
         if: steps.check_changes.outputs.has_changes == 'false'
         run: |
-          echo "ℹ No new data extracted - repository is up to date"
+          echo "[info] No new data extracted - repository is up to date"
           echo "This is expected for delta mode when there are no new records"
 
       # ============================================================
@@ -315,7 +328,7 @@ EOF
         if: failure()
         run: |
           echo "=================================================="
-          echo "⚠️  WORKFLOW FAILED"
+          echo "[WARN]  WORKFLOW FAILED"
           echo "=================================================="
           echo ""
           echo "Please check:"

--- a/scripts/validation/check_workflow_disarm.py
+++ b/scripts/validation/check_workflow_disarm.py
@@ -1,0 +1,153 @@
+"""Assert that the write-capable workflows stay de-armed.
+
+Why this exists
+---------------
+Two workflows in this repository can commit to the repository:
+
+    data-pipeline-automation.yml   runs clean_events.py, rewrites data/serveable/
+    weekly-data-refresh.yml        extracts to data/raw/, which is immutable
+
+Both were, until 2026-07-30, inert only because of a YAML syntax error. Anyone
+who repaired the syntax -- a reasonable thing to do when asked to "fix the
+broken CI" -- would have armed a bot that rewrites the serveable zone from
+1,194 records to 28 on the next push touching data/raw/.
+
+The repair landed together with a trigger de-arm. But a de-arm that lives only
+in a YAML comment is one careless edit from being undone, and the person who
+undoes it will not have read the comment. So the constraint is asserted here
+instead, where it fails a build.
+
+This does not claim the workflows are correct. It claims only that they cannot
+run unattended.
+
+Re-arming, deliberately
+-----------------------
+Remove the workflow from DISARMED below, in the same commit that arms it, with
+the reasoning in the commit message. That makes arming a visible, reviewable
+act rather than a side effect.
+"""
+import io
+import os
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write(
+        "check_workflow_disarm: PyYAML is required.\n"
+        "  pip install pyyaml\n"
+    )
+    sys.exit(3)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+WORKFLOW_DIR = os.path.join(REPO_ROOT, ".github", "workflows")
+
+# workflow filename -> why it must not run unattended
+DISARMED = {
+    "data-pipeline-automation.yml":
+        "stage 2A runs clean_events.py, which rewrites data/serveable/ and "
+        "auto-commits; the canonical producer for that zone is unsettled",
+    "weekly-data-refresh.yml":
+        "auto-commits extracted data into data/raw/, a zone whose contract "
+        "says dumps are immutable and re-runs produce new dumps",
+}
+
+# Triggers that fire without a human deciding to fire them.
+UNATTENDED = ("push", "schedule", "pull_request", "pull_request_target",
+              "issue_comment", "repository_dispatch")
+
+failures = []
+notes = []
+
+
+def trigger_keys(doc):
+    """Return the trigger names for a parsed workflow.
+
+    PyYAML resolves the unquoted key `on` to the boolean True under YAML 1.1
+    -- the same class of surprise as the Norway problem, where `no` becomes
+    False. GitHub Actions reads YAML 1.2, where `on` stays a string. So the
+    key can arrive either way and both must be tried.
+    """
+    trig = doc.get("on")
+    if trig is None:
+        trig = doc.get(True)
+    if trig is None:
+        return None
+    if isinstance(trig, dict):
+        return sorted(trig.keys())
+    if isinstance(trig, list):
+        return sorted(str(t) for t in trig)
+    return [str(trig)]
+
+
+def main():
+    if not os.path.isdir(WORKFLOW_DIR):
+        print("no .github/workflows directory; nothing to check")
+        return 0
+
+    present = set(os.listdir(WORKFLOW_DIR))
+
+    for name, reason in sorted(DISARMED.items()):
+        if name not in present:
+            notes.append("%s is listed as de-armed but no longer exists "
+                         "(renamed or deleted?)" % name)
+            continue
+
+        path = os.path.join(WORKFLOW_DIR, name)
+        text = io.open(path, encoding="utf-8").read()
+
+        try:
+            doc = yaml.safe_load(text)
+        except yaml.YAMLError as e:
+            failures.append("%s does not parse as YAML: %s"
+                            % (name, str(e).splitlines()[0]))
+            continue
+
+        if not isinstance(doc, dict):
+            failures.append("%s did not parse to a mapping" % name)
+            continue
+
+        keys = trigger_keys(doc)
+        if keys is None:
+            failures.append("%s has no trigger block at all" % name)
+            continue
+
+        armed = [k for k in keys if k in UNATTENDED]
+        if armed:
+            failures.append(
+                "%s is ARMED on %s.\n"
+                "      Why this is guarded: %s.\n"
+                "      If arming is intended, remove the entry from DISARMED in\n"
+                "      %s in the same commit."
+                % (name, "/".join(armed), reason,
+                   os.path.relpath(__file__, REPO_ROOT).replace("\\", "/")))
+        else:
+            print("ok   %-32s triggers: %s" % (name, ", ".join(keys) or "(none)"))
+
+    # Every workflow must parse, de-armed or not. A file that does not parse is
+    # a workflow whose triggers cannot be reasoned about.
+    for name in sorted(present):
+        if not name.endswith((".yml", ".yaml")):
+            continue
+        path = os.path.join(WORKFLOW_DIR, name)
+        try:
+            yaml.safe_load(io.open(path, encoding="utf-8").read())
+        except yaml.YAMLError as e:
+            failures.append("%s does not parse as YAML: %s"
+                            % (name, str(e).splitlines()[0]))
+
+    for n in notes:
+        print("note: " + n)
+
+    if failures:
+        print()
+        for f in failures:
+            print("FAIL: " + f)
+        return 1
+
+    print("\nAll write-capable workflows are de-armed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the ordering constraint in #30: the YAML repair and the trigger de-arm land in the same commit, because doing either alone is worse than doing neither.

## Why the broken CI was load-bearing

`data-pipeline-automation.yml` runs `clean_events.py` at stage 2A and auto-commits. That script's output is 28 records where `all_events.json` holds 1,194. It was armed on push to `data/raw/**`. The only thing preventing a data-clobbering auto-commit was a YAML syntax error in the same file — so "fix the broken CI" was, until this PR, an instruction that would have destroyed data.

## What changed

**Repaired** — heredoc bodies and inline python sat at column 0 inside a `run: |` block scalar, which terminates the scalar and makes YAML parse the body as new keys. Indented to the block indentation; bash and python still receive them at column 0 after YAML strips it. Verified every heredoc still opens and closes correctly post-stripping.

**De-armed** — `push`/`paths` off the pipeline workflow, `schedule` off the weekly refresh, `workflow_dispatch` retained on both.

**Third landmine, not in the audit plan, found while checking the others.** `documentation-ci.yml`'s `documentation-publish` job appends five lines to `DEVBLOG.md` with `echo >>` and pushes, on every push to main — so the file grows without bound. It has never run because it `needs` a job that fails on the ASCII gate. That makes it the same trap in a different file: *clearing the ASCII backlog would arm it as a side effect.* Commented out with the reasoning; whether build provenance belongs in DEVBLOG.md at all is an owner call.

This is also why the 20-file ASCII backlog is deliberately untouched here. Only the 9 glyphs in a file already being edited, via an explicit substitution map that errors on an unmapped character rather than falling back to `?` (the existing `fix_ascii.py` would shred the tree diagrams).

## The part that outlives this PR

A de-arm living in a YAML comment is one careless edit from gone, and whoever undoes it will not have read the comment. `scripts/validation/check_workflow_disarm.py` fails the build if either workflow regains an unattended trigger, and names the reason inline.

Negative-tested rather than assumed: with the `push` trigger restored it exits 1 and reports the arming, and the file was restored byte-identical afterwards.

Adds `data-integrity.yml` — `contents: read`, no write path, so arming it is safe. Runs the de-arm guard, `check_invariants.py`, `project_candidates.py --check`, and both test files directly. Only PyYAML is installed; everything else is stdlib, so it cannot break on dependency drift.

## Verified locally

4/4 workflows parse · 2/2 de-armed · invariants hold · serveable rebuild byte-identical · tests 7/7 and 3/3.

Refs #30