### PR TITLE
feat: Frontier AI labs collection (46 orgs), with evidence carried per date

### DIFF
--- a/.github/workflows/data-integrity.yml
+++ b/.github/workflows/data-integrity.yml
@@ -65,8 +65,11 @@ jobs:
       - name: Repository invariants hold
         run: python scripts/validation/check_invariants.py
 
-      - name: Serveable zone matches a fresh build
+      - name: Serveable zone matches a fresh build (candidates)
         run: python scripts/build/project_candidates.py --check
+
+      - name: Serveable zone matches a fresh build (frontier labs)
+        run: python scripts/build/project_frontier_labs.py --check
 
       - name: Dump-space tests
         run: python tests/test_dump_spaces.py

--- a/config/schemas/frontier_labs_v1.json
+++ b/config/schemas/frontier_labs_v1.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://pdoom.com/schemas/frontier_labs_v1.json",
+  "title": "Frontier AI Labs Schema",
+  "description": "Organisations that develop frontier AI systems, with founding dates carried alongside the evidence for them. Facts only: this collection asserts no game impacts, no rarity and no salience. Inclusion is itself an editorial judgement and is therefore recorded per row in inclusion_basis rather than left implicit.",
+  "version": "1.0.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "founded",
+    "founded_precision",
+    "evidence_strength",
+    "status",
+    "lab_kind",
+    "inclusion_basis",
+    "sources"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Stable slug. Never reused, never renamed; a rename creates a new id and sets the old row's status to renamed.",
+      "pattern": "^[a-z0-9_]+$",
+      "minLength": 2,
+      "maxLength": 64
+    },
+    "name": {
+      "type": "string",
+      "description": "Display name, ASCII only. Source dumps in this repo carry encoding damage (for example 'UniversitA de MontrAal'), so names here are re-typed rather than copied.",
+      "minLength": 2,
+      "maxLength": 120
+    },
+    "aliases": {
+      "type": "array",
+      "description": "Other names the same organisation appears under, including names used in the Epoch AI dump.",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "founded": {
+      "type": ["string", "null"],
+      "description": "ISO 8601 date at the precision the evidence supports: YYYY, YYYY-MM or YYYY-MM-DD. NULL WHERE NO CITED DATE WAS FOUND. Null is ungated and honest; a fabricated date is indistinguishable from a real one later. Do not fill this from memory or by inference from a relative phrase such as 'founded two years ago'.",
+      "pattern": "^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$"
+    },
+    "founded_precision": {
+      "type": ["string", "null"],
+      "description": "Precision actually supported by founded_evidence. Must be null exactly when founded is null.",
+      "enum": ["day", "month", "year", null]
+    },
+    "founded_evidence": {
+      "type": ["object", "null"],
+      "description": "What was read, and the sentence that carried the date. Present even where founded is null, to record what was checked.",
+      "additionalProperties": false,
+      "required": ["url", "quote", "publisher"],
+      "properties": {
+        "url": { "type": "string", "description": "The page actually fetched" },
+        "quote": { "type": "string", "description": "Verbatim sentence from that page containing the date" },
+        "publisher": { "type": "string", "description": "Who publishes the page, and any record identifier such as a company number" }
+      }
+    },
+    "founded_contested": {
+      "type": "boolean",
+      "description": "True where credible sources disagree, or where founded / incorporated / announced / emerged-from-stealth are meaningfully different events.",
+      "default": false
+    },
+    "founded_alternatives": {
+      "type": "array",
+      "description": "Other defensible dates, each labelled with what it represents. A consumer wanting 'when did this lab become publicly visible' should read this rather than founded.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["date", "what_it_represents"],
+        "properties": {
+          "date": { "type": ["string", "null"] },
+          "url": { "type": "string" },
+          "quote": { "type": "string" },
+          "what_it_represents": {
+            "type": "string",
+            "description": "For example: statutory incorporation, public announcement, emergence from stealth, internal project start"
+          }
+        }
+      },
+      "default": []
+    },
+    "evidence_strength": {
+      "type": "string",
+      "description": "How much weight founded can bear. Graded on source class, not on confidence. 'registry' = a statutory company register. 'first_party' = the organisation's own site. 'press' = journalism that states the date. 'secondary' = encyclopedia or trade-press boilerplate, or a citation chain that does not resolve. 'none' = no citable date found; founded must be null.",
+      "enum": ["registry", "first_party", "press", "secondary", "none"]
+    },
+    "status": {
+      "type": "string",
+      "description": "Current disposition. Note that a reverse-acquihire, where staff and a licence move but no equity changes hands, is NOT 'acquired'; such organisations stay 'active' with the event recorded in notes.",
+      "enum": ["active", "acquired", "merged", "defunct", "renamed", "unknown"]
+    },
+    "status_date": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$"
+    },
+    "status_evidence": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["url", "quote"],
+      "properties": {
+        "url": { "type": "string" },
+        "quote": { "type": "string" }
+      }
+    },
+    "parent_org": {
+      "type": ["string", "null"],
+      "description": "id of the parent row where the parent is also in this collection, otherwise a plain name. Set only where an equity relationship is evidenced."
+    },
+    "country": {
+      "type": ["string", "null"],
+      "description": "Country of headquarters at founding. Null where genuinely unclear rather than guessed; some organisations are dual-sited from the start."
+    },
+    "lab_kind": {
+      "type": "string",
+      "description": "What kind of thing this row is. Provided so that a consumer counting 'how many frontier labs exist' picks its own filter instead of inheriting ours. A count of dedicated_ai_lab is a very different number from a count of every row.",
+      "enum": [
+        "dedicated_ai_lab",
+        "corporate_division",
+        "corporate_parent",
+        "research_institute",
+        "research_collective"
+      ]
+    },
+    "inclusion_basis": {
+      "type": "string",
+      "description": "Why this row is in the collection. 'epoch_frontier_model' is mechanical: credited on at least one model flagged Frontier model in the Epoch AI notable-models database with a publication date in range. 'editorial' is a judgement call, and inclusion_reason must then say why the mechanical rule missed it.",
+      "enum": ["epoch_frontier_model", "editorial"]
+    },
+    "inclusion_reason": {
+      "type": ["string", "null"],
+      "description": "Required where inclusion_basis is editorial. States what the mechanical rule missed and why the row belongs anyway."
+    },
+    "epoch_frontier_models": {
+      "type": ["integer", "null"],
+      "description": "Count of Epoch-flagged frontier models this organisation is credited on, in range. Null where the organisation does not appear in the Epoch dump at all, which is different from zero.",
+      "minimum": 0
+    },
+    "epoch_first_frontier_model": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$",
+      "description": "Publication date of the earliest Epoch-flagged frontier model credited to this organisation. A weak lower bound on when the organisation was doing frontier work, and NOT a founding date."
+    },
+    "epoch_last_frontier_model": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$"
+    },
+    "sources": {
+      "type": "array",
+      "description": "Every URL consulted for this row, including ones that did not yield a date.",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "notes": {
+      "type": ["string", "null"],
+      "description": "What a careful reader should know. Decoy corporate records that were rejected belong here, so the next person does not re-find them and adopt them."
+    },
+    "extra": {
+      "type": "object",
+      "description": "Escape hatch for fields not yet standardised. Anything here is unversioned and may move into a named field in a later schema version. Reserved for: funding_total, headcount_band, notable_models, safety_team_presence, jurisdiction.",
+      "default": {}
+    }
+  },
+  "allOf": [
+    {
+      "description": "founded and founded_precision agree about being absent.",
+      "if": { "properties": { "founded": { "type": "null" } } },
+      "then": { "properties": { "founded_precision": { "type": "null" } } }
+    },
+    {
+      "description": "A null founded must be justified by evidence_strength none.",
+      "if": { "properties": { "founded": { "type": "null" } } },
+      "then": { "properties": { "evidence_strength": { "const": "none" } } }
+    },
+    {
+      "description": "An editorial inclusion must say why the mechanical rule missed it.",
+      "if": { "properties": { "inclusion_basis": { "const": "editorial" } } },
+      "then": { "required": ["inclusion_reason"], "properties": { "inclusion_reason": { "type": "string", "minLength": 10 } } }
+    }
+  ]
+}

--- a/data/enrichment/frontier_labs/README.md
+++ b/data/enrichment/frontier_labs/README.md
@@ -97,7 +97,7 @@ honest; a fabricated clock is indistinguishable from a real one later. Every
 non-null `founded` carries `founded_evidence` with the URL that was read and
 the verbatim sentence containing the date.
 
-**Three rows have `founded: null` on purpose.**
+**Four rows have `founded: null` on purpose.**
 
 - **Google Research** -- the only date available is an *uncited* Wikipedia
   infobox value. Google Research appears to be an organisational label that
@@ -110,6 +110,21 @@ the verbatim sentence containing the date.
   traces to the phrase "founded two years ago" in an article datelined
   2024-06-28. The well-evidenced public launch (2022-04-26) is in
   `founded_alternatives`, labelled as a launch.
+- **NAVER AI Lab** -- NAVER's own careers page for the lab describes its
+  mission and research fields and gives no date. Only adjacent facts are
+  sourceable (CLOVA introduced 2017-03, HyperCLOVA 2021-05, CLOVA folded into
+  NAVER Cloud in 2023). The row is kept rather than dropped, because a null
+  with a documented search distinguishes "we looked and could not find" from
+  "we did not consider this".
+
+**One row was downgraded by the curator against the researcher's finding.**
+AI21 Labs came back at month precision (November 2017) on Wikipedia's
+authority. Following Wikipedia's own cited source through -- a Globes article
+on AI21's funding round -- shows it contains no founding date at all. The month
+is therefore unsupported by the citation offered for it, and `founded` is
+recorded as `2017` at year precision with the month demoted to
+`founded_alternatives` and the reason stated. A confident-sounding month whose
+citation does not check out is weaker evidence than a plain year that does.
 
 ### `evidence_strength` grades the source class, not the confidence
 
@@ -179,6 +194,25 @@ Split so evidence and judgement can be reviewed separately. The projection
 asserts both directions: a researched organisation missing from the curation
 table fails the build rather than being silently dropped, and a curation entry
 for something nobody researched fails too.
+
+## Coverage, measured
+
+46 organisations: 24 by the mechanical rule, 22 editorial. Evidence grades:
+5 `registry`, 15 `first_party`, 8 `press`, 14 `secondary`, 4 `none`. Sixteen
+rows carry `founded_contested: true`.
+
+That `secondary` count is the honest weak spot. Roughly a third of rows rest on
+an encyclopedia or a trade-press line rather than a register or a first-party
+statement, usually because the organisation is an internal division with no
+incorporation record to appeal to. Upgrading those is the obvious next pass.
+
+**A cross-source check runs on every build.** An organisation cannot be
+credited on an Epoch frontier model published before it existed, and founding
+dates and Epoch publication dates come from entirely independent sources, so a
+violation means one of them is wrong. It currently exercises 22 of 46 rows and
+is not vacuous: the tightest margin is Google DeepMind, founded 2023-04-20 with
+its first flagged model on 2023-12-06, so a founding date wrong by a year would
+fire it.
 
 ## Rebuilding
 

--- a/data/enrichment/frontier_labs/README.md
+++ b/data/enrichment/frontier_labs/README.md
@@ -1,0 +1,210 @@
+# Frontier AI labs
+
+Organisations that develop frontier AI systems, with founding dates carried
+alongside the evidence for them.
+
+Built by `scripts/build/project_frontier_labs.py` into
+`data/serveable/api/frontier_labs/`. Schema:
+`config/schemas/frontier_labs_v1.json`.
+
+Consumers: pdoom1 (engine integration, game issue #962) and pdoom1-website,
+whose `scripts/calculate-game-stats.py` currently derives `frontier_labs_count`
+from a hardcoded list. Filed as pdoom-data#37.
+
+---
+
+## What counts as "frontier"
+
+This is the contestable part of the deliverable, so it is stated here rather
+than left implicit in whoever typed the rows.
+
+**A definition based on current capability would be wrong for this dataset.**
+The collection feeds a timeline that runs from 2000 to the present, so it needs
+organisations that *were* at the frontier at some point, not only those at it
+today. A rule that excluded DeepMind-in-2015 or Google-Brain-in-2012 would be
+useless for the thing it is for.
+
+So inclusion is a disjunction, and which branch applied is recorded per row in
+`inclusion_basis`.
+
+### A. `epoch_frontier_model` -- mechanical
+
+Credited on at least one model flagged `Frontier model` in the Epoch AI
+notable-models database, with a publication date in 2000 or later, and not
+purely academic.
+
+This is a query, not a judgement. Epoch's flag is era-relative -- it marks the
+1958 Perceptron as frontier for its time -- which is exactly the property the
+timeline needs. Epoch AI's database is CC-BY-4.0 and is already ingested at
+`data/raw/epoch_ai/`.
+
+### B. `editorial` -- judgement, with a stated reason
+
+Included although the mechanical rule did not select it. Every such row must
+carry `inclusion_reason` naming *what the rule missed*.
+
+**This branch is not a convenience.** Epoch's frontier flag is sparse: 123 of
+1,034 rows in the ingested dump carry it. Its absence is therefore not evidence
+that an organisation is not frontier. The decisive case is **DeepSeek**, which
+has no flagged row in the dump at all despite V3 and R1 being unambiguously
+frontier on release. A mechanical-only rule would have shipped a frontier-labs
+dataset with no DeepSeek in it. Mistral, Alibaba, Cohere and Anthropic-adjacent
+newer labs are further examples.
+
+Two rows are deliberately borderline rather than quietly omitted:
+
+- **Hugging Face** is arguably infrastructure, not a frontier lab. It is
+  included so the boundary of the rule is visible *in the data*, where a
+  disagreeing consumer can filter it, rather than hidden in a decision nobody
+  recorded.
+- **Safe Superintelligence** has released no model and so cannot appear in a
+  model database by construction. Filter on `epoch_frontier_models` being null
+  if you want only shipping labs.
+
+### Counting: read `lab_kind` before you count rows
+
+`frontier_labs_count` is not `len(labs)`. The collection deliberately mixes:
+
+| `lab_kind` | Example |
+|---|---|
+| `dedicated_ai_lab` | DeepMind, Mistral AI, DeepSeek |
+| `corporate_division` | Google Brain, Tencent AI Lab, ByteDance Seed |
+| `corporate_parent` | Google, Microsoft, Amazon, NVIDIA |
+| `research_institute` | Allen Institute for AI, Peng Cheng Laboratory |
+| `research_collective` | EleutherAI |
+
+Counting every row double-counts Google (which appears as Google, Google
+Research, Google Brain, DeepMind and Google DeepMind, each with its own
+founding date and its own end). That redundancy is intentional -- collapsing
+them would destroy the merger and lineage facts -- but it means the consumer
+must choose a filter. We do not choose one for you; that is the fact/opinion
+firewall applied to counting.
+
+**Two rows will inflate a naive count of currently-active frontier labs:**
+
+- **Tencent AI Lab** was disbanded into the Hunyuan team on 2026-03-20
+  (`status: merged`).
+- **01.AI** stopped pre-training its own models in 2025-03 and now builds on
+  DeepSeek's. It remains an operating company, so `status` is still `active`;
+  the change is recorded in `status_date` and `notes`.
+
+---
+
+## Dates, and why several of them are null
+
+The standing rule in this repo is **never guess a date**. `null` is ungated and
+honest; a fabricated clock is indistinguishable from a real one later. Every
+non-null `founded` carries `founded_evidence` with the URL that was read and
+the verbatim sentence containing the date.
+
+**Three rows have `founded: null` on purpose.**
+
+- **Google Research** -- the only date available is an *uncited* Wikipedia
+  infobox value. Google Research appears to be an organisational label that
+  accreted rather than being founded: renamed to Google AI in 2018 and back,
+  with the Brain team moving into and out of it.
+- **Inspur** -- four mutually inconsistent dates circulate (1945, 1983, 1989,
+  1998) because "Inspur" is not one organisation. Whoever consumes this row
+  must first decide which entity is meant.
+- **Adept AI** -- no source states a founding date. The widely repeated "2022"
+  traces to the phrase "founded two years ago" in an article datelined
+  2024-06-28. The well-evidenced public launch (2022-04-26) is in
+  `founded_alternatives`, labelled as a launch.
+
+### `evidence_strength` grades the source class, not the confidence
+
+`registry` > `first_party` > `press` > `secondary` > `none`. This is
+deliberately mechanical, because "how sure am I" is not a property of the
+evidence. Mistral AI scores `registry` (French government SIREN 952418325);
+Hugging Face scores `secondary`, because no first-party page states a founding
+year and Wikipedia's own citation does not confirm the date when followed
+through.
+
+### `founded_contested` and `founded_alternatives`
+
+Where founded / incorporated / announced / emerged-from-stealth are different
+events, all of them are recorded and labelled. A consumer wanting "when did
+this lab become publicly visible" should read `founded_alternatives`, not
+`founded`.
+
+This structure converged on a subset of Wikidata's statement model -- value
+plus qualifiers plus references, with contested values coexisting rather than
+one overwriting the others. Read their model before extending this one.
+
+---
+
+## Traps found while building this, recorded so nobody re-finds them
+
+- **DeepMind's September/November ambiguity runs the opposite way to the usual
+  telling.** Companies House shows entity 07386350 incorporated 2010-09-23
+  under the shelf-company name `FRIARS 2022 LIMITED`, renamed DeepMind
+  Technologies Limited on 2010-11-15. September is "a legal entity exists" and
+  may be the shelf company's registration rather than any act by the founders.
+  November is "DeepMind exists", and is what `founded` records.
+- **Compaq CRL was not founded by Compaq.** DEC founded it in 1987 as DEC's
+  Cambridge Research Laboratory; Compaq inherited it in 1998 and HP in 2002.
+  The Epoch dump's org string flattens a three-parent lineage.
+- **Stability AI's founding date misrepresents it.** Incorporated 2019-11-04,
+  but with essentially no public AI-lab activity until Stable Diffusion in
+  2022-08. Anyone comparing `founded` across labs will over-age Stability by
+  about three years.
+- **Qwen is not in DAMO Academy.** Alibaba moved DAMO's language and vision
+  teams into Alibaba Cloud's Tongyi Lab in late 2022. The DAMO row is not the
+  right home for Qwen.
+- **Two reverse-acquihires are not acquisitions.** Character.AI (Google, 2024)
+  and Adept (Amazon, 2024) both had founders hired and technology licensed
+  without equity changing hands, and both continued operating. `status` stays
+  `active` for each, with the event in `notes`. `parent_org` is null because no
+  acquisition is evidenced.
+- **Decoy corporate records, rejected and recorded.** UK Companies House lists
+  `REKA AI LTD.` (14242489, incorporated 2022-07-19, Altrincham) whose date is
+  temptingly close but whose office, size and profile do not match the
+  Sunnyvale lab. A wrong SIREN (952481660) for Mistral circulates in secondary
+  write-ups. Both are named in the relevant rows' `notes` so the next person
+  does not adopt them.
+- **MERL's name has a four-year gap.** It was called ITA from 1996 to 2000,
+  which matters when matching on organisation name across a time series.
+
+---
+
+## Layout
+
+    research/*.json      what was read. Each row carries URL and verbatim
+                         quote. An evidence record: do not edit to change a
+                         verdict.
+    curation_table.json  the judgement calls -- id, lab_kind, inclusion_basis,
+                         aliases, and the reason for each editorial inclusion.
+
+Split so evidence and judgement can be reviewed separately. The projection
+asserts both directions: a researched organisation missing from the curation
+table fails the build rather than being silently dropped, and a curation entry
+for something nobody researched fails too.
+
+## Rebuilding
+
+    python scripts/build/project_frontier_labs.py           # build
+    python scripts/build/project_frontier_labs.py --check   # assert committed
+
+`data/serveable/` is a build output; never hand-edit it. `--check` asserts the
+committed feed is byte-identical to a fresh build. `LINEAGE.json` deliberately
+carries no wall-clock stamp -- a `built_at` field is exactly what made the
+candidate feed's rebuild-idempotence claim false.
+
+## Deliberately not here
+
+No game impacts, no rarity, no salience, no `game_facing` flag. Promotion to
+the game is the consumer's call. Per ADR-001's stated direction and pdoom-data#34,
+pdoom1's resource model belongs in an export profile, not the shared schema.
+
+Reserved for later without a breaking change, via the `extra` escape hatch:
+`funding_total`, `headcount_band`, `notable_models`, `safety_team_presence`,
+`jurisdiction`.
+
+## Known incompleteness
+
+The inclusion rule's mechanical branch is only as good as the Epoch dump's
+coverage, which skews toward language models with published compute figures.
+Image, video, speech and robotics labs are under-represented, and the editorial
+branch has not been systematically swept for them. Adding an inclusion basis
+drawn from a governance instrument -- for example a frontier-safety-commitment
+signatory list -- would be the natural third branch.

--- a/data/enrichment/frontier_labs/curation_table.json
+++ b/data/enrichment/frontier_labs/curation_table.json
@@ -6,6 +6,87 @@
     "lab_kind": "Provided so a consumer counting 'how many frontier labs exist' picks its own filter rather than inheriting ours. Counting dedicated_ai_lab gives a very different number from counting every row."
   },
   "labs": {
+    "OpenAI": {
+      "id": "openai",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["OpenAI"]
+    },
+    "Anthropic": {
+      "id": "anthropic",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Anthropic"]
+    },
+    "xAI": {
+      "id": "xai",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["xAI", "X.AI Corp."]
+    },
+    "Meta AI": {
+      "id": "meta_ai",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Meta AI", "FAIR", "Facebook AI Research", "Fundamental AI Research"]
+    },
+    "Meta Platforms": {
+      "id": "meta_platforms",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Facebook", "Facebook AI", "TheFacebook, Inc."]
+    },
+    "Inflection AI": {
+      "id": "inflection_ai",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Inflection AI"]
+    },
+    "AI21 Labs": {
+      "id": "ai21_labs",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["AI21 Labs"]
+    },
+    "Technology Innovation Institute": {
+      "id": "technology_innovation_institute",
+      "lab_kind": "research_institute",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Technology Innovation Institute", "TII"]
+    },
+    "NAVER": {
+      "id": "naver",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["NAVER", "Naver Corporation", "Naver Comm"]
+    },
+    "NAVER Cloud": {
+      "id": "naver_cloud",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch under this name. Included because HyperCLOVA X and NAVER's model work sit under this entity rather than under NAVER Corporation, so a consumer following parent_org from NAVER AI Lab needs it to exist.",
+      "aliases": ["NAVER Business Platform", "NBP"]
+    },
+    "NAVER AI Lab": {
+      "id": "naver_ai_lab",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch. Included as NAVER's dedicated AI research lab, and retained despite having no sourceable founding date at all -- a null row with a documented search is more useful to a consumer than a silent absence, because it distinguishes 'we looked and could not find' from 'we did not consider this'.",
+      "aliases": ["Clova AI Research"]
+    },
+    "Baidu": {
+      "id": "baidu",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Baidu"]
+    },
+    "Baidu Research": {
+      "id": "baidu_research",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch under this name; the flagged Baidu row attaches to the parent. Included separately because Baidu Research has a distinct, well-dated public launch (2014-05-16) and was the organisational home of Baidu's frontier work under Andrew Ng.",
+      "aliases": ["Institute of Deep Learning", "Silicon Valley AI Lab"]
+    },
     "Google": {
       "id": "google",
       "lab_kind": "corporate_parent",

--- a/data/enrichment/frontier_labs/curation_table.json
+++ b/data/enrichment/frontier_labs/curation_table.json
@@ -1,0 +1,227 @@
+{
+  "_about": "The editorial layer over data/enrichment/frontier_labs/research/*.json. The research files record what was read and are not edited; this file records the judgement calls, so the two can be reviewed separately. Keyed by the 'name' field as it appears in the research files.",
+  "_inclusion_rule_v1": {
+    "epoch_frontier_model": "Credited on at least one model flagged 'Frontier model' in the Epoch AI notable-models database with a publication date in 2000 or later. Mechanical: it is a query, not a judgement.",
+    "editorial": "Included despite the mechanical rule not selecting it. Requires inclusion_reason naming what the rule missed. Necessary because Epoch's flag is sparse -- 123 of 1,034 rows in the dump carry it -- so its absence is not evidence an organisation is not frontier.",
+    "lab_kind": "Provided so a consumer counting 'how many frontier labs exist' picks its own filter rather than inheriting ours. Counting dedicated_ai_lab gives a very different number from counting every row."
+  },
+  "labs": {
+    "Google": {
+      "id": "google",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Google"]
+    },
+    "Google Research": {
+      "id": "google_research",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Google Research"]
+    },
+    "Google Brain": {
+      "id": "google_brain",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Google Brain"]
+    },
+    "DeepMind": {
+      "id": "deepmind",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["DeepMind"]
+    },
+    "Google DeepMind": {
+      "id": "google_deepmind",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Google DeepMind"]
+    },
+    "Microsoft": {
+      "id": "microsoft",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Microsoft"]
+    },
+    "Microsoft Research": {
+      "id": "microsoft_research",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Microsoft Research"]
+    },
+    "NVIDIA": {
+      "id": "nvidia",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["NVIDIA"]
+    },
+    "Amazon": {
+      "id": "amazon",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Amazon"]
+    },
+    "IBM": {
+      "id": "ibm",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Epoch flags IBM on frontier models only BEFORE 2000, so the 2000+ window rule does not select it. Included because the collection's window is a scoping choice, not a claim that IBM stopped being a research organisation, and because a timeline running to the present benefits from an entity whose frontier work predates the window.",
+      "aliases": ["IBM"]
+    },
+    "Cambridge Research Laboratory": {
+      "id": "cambridge_research_laboratory",
+      "lab_kind": "research_institute",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Compaq CRL"]
+    },
+    "Mitsubishi Electric Research Laboratories": {
+      "id": "mitsubishi_electric_research_laboratories",
+      "lab_kind": "research_institute",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Mitsubishi Electric Research Labs", "MERL", "Mitsubishi Electric Information Technology Center America", "ITA"]
+    },
+    "Mistral AI": {
+      "id": "mistral_ai",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "No Mistral model carries Epoch's frontier flag in the ingested dump, but Mistral trains and releases general-purpose models at or near the open-weight frontier and is routinely named as a frontier developer in European AI governance discussion. A clear case of the flag's sparsity rather than of Mistral not qualifying.",
+      "aliases": []
+    },
+    "Cohere": {
+      "id": "cohere",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included as a dedicated general-purpose model developer with its own pretrained frontier-class family, whose absence from the flag reflects Epoch's coverage rather than Cohere's activity.",
+      "aliases": []
+    },
+    "Stability AI": {
+      "id": "stability_ai",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump, whose frontier flag tracks language-model compute far better than image generation. Included because Stable Diffusion was at the generative-image frontier on release. Note the founding date badly misrepresents this row: see notes.",
+      "aliases": []
+    },
+    "Safe Superintelligence Inc": {
+      "id": "safe_superintelligence",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Has released no model, so it cannot appear in a model database by construction. Included because a dataset of frontier labs that omits an explicitly frontier-targeting lab founded by Ilya Sutskever would mislead; a consumer wanting only shipping labs can filter on epoch_frontier_models being null.",
+      "aliases": []
+    },
+    "Allen Institute for AI": {
+      "id": "allen_institute_for_ai",
+      "lab_kind": "research_institute",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included as a non-profit institute releasing fully open pretrained models and training data, which makes it structurally important to the field even where its models are not compute-frontier.",
+      "aliases": ["AI2", "Ai2"]
+    },
+    "EleutherAI": {
+      "id": "eleutherai",
+      "lab_kind": "research_collective",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included because it was for a period the main source of openly available large language models, and because it is the collection's clearest example of an organisation with no incorporation date -- useful as a test of the schema's tolerance for ill-defined founding.",
+      "aliases": []
+    },
+    "Hugging Face": {
+      "id": "hugging_face",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch, and arguably infrastructure rather than a frontier lab. Included as a borderline case, deliberately, so that the boundary of the inclusion rule is visible in the data rather than hidden in a decision nobody recorded. A consumer disagreeing should filter it out; that is what lab_kind and inclusion_basis are for.",
+      "aliases": []
+    },
+    "Reka AI": {
+      "id": "reka_ai",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included as a dedicated multimodal frontier-model developer founded by former DeepMind and Google Brain researchers.",
+      "aliases": []
+    },
+    "Character.AI": {
+      "id": "character_ai",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch. Included because it trained its own large models in-house rather than building on someone else's, and because its 2024 reverse-acquihire is a useful worked example of an event that looks like an acquisition and is not.",
+      "aliases": []
+    },
+    "Adept AI": {
+      "id": "adept_ai",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch. Included as an agent-focused frontier developer founded by transformer co-authors, and as the collection's clearest case of a founding date that could not be sourced at all.",
+      "aliases": []
+    },
+    "DeepSeek": {
+      "id": "deepseek",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "The most conspicuous gap in Epoch's frontier flag within the ingested dump: DeepSeek carries no flagged row, despite V3 and R1 being unambiguously frontier on release. This single row is the strongest evidence that a mechanical-only inclusion rule would have produced a wrong dataset.",
+      "aliases": []
+    },
+    "Alibaba DAMO Academy": {
+      "id": "alibaba_damo_academy",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch under this name. Included as Alibaba's research institute, with the important caveat recorded in notes that the Qwen team moved out of DAMO into Alibaba Cloud's Tongyi Lab in late 2022 -- so this row is NOT the right home for Qwen and a consumer should not treat it as such.",
+      "aliases": ["DAMO Academy", "Alibaba DAMO"]
+    },
+    "Moonshot AI": {
+      "id": "moonshot_ai",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included as a dedicated Chinese frontier-model developer (Kimi series) widely tracked as frontier-adjacent.",
+      "aliases": ["Kimi"]
+    },
+    "Zhipu AI": {
+      "id": "zhipu_ai",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Z.ai (Zhipu AI)", "Z.ai", "Beijing Zhipu Huazhang Technology Co., Ltd."]
+    },
+    "01.AI": {
+      "id": "zero_one_ai",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included for the Yi model family. Note the status change recorded in the row: 01.AI stopped pre-training its own models in 2025-03, so any count of currently-active frontier labs should exclude it after that date.",
+      "aliases": ["Yi", "Beijing Lingyi Wanwu Information Technology Co., Ltd."]
+    },
+    "ByteDance Seed": {
+      "id": "bytedance_seed",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch under this name. Included as ByteDance's frontier model team (Doubao / Seed series). The unit has been reconstituted at least once since its 2023 establishment, which the row records.",
+      "aliases": ["Seed", "ByteDance"]
+    },
+    "Tencent": {
+      "id": "tencent",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included as the parent of the Hunyuan model family and, from 2026-03, of the absorbed AI Lab. Present mainly to give Tencent AI Lab a parent to point at.",
+      "aliases": []
+    },
+    "Tencent AI Lab": {
+      "id": "tencent_ai_lab",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch. Included as a separate row from Tencent because it has a distinct founding date (2016-04) and a distinct end: it was disbanded into the Hunyuan team on 2026-03-20. A collection that folded it into Tencent would lose both facts.",
+      "aliases": []
+    },
+    "Huawei Noah's Ark Lab": {
+      "id": "huawei_noahs_ark_lab",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included as Huawei's principal AI research lab and the origin of the Pangu model family.",
+      "aliases": ["Noah's Ark Lab"]
+    },
+    "Inspur": {
+      "id": "inspur",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Inspur"]
+    },
+    "Peng Cheng Laboratory": {
+      "id": "peng_cheng_laboratory",
+      "lab_kind": "research_institute",
+      "inclusion_basis": "epoch_frontier_model",
+      "aliases": ["Peng Cheng Laboratory"]
+    }
+  }
+}

--- a/data/enrichment/frontier_labs/research/batch1.json
+++ b/data/enrichment/frontier_labs/research/batch1.json
@@ -1,0 +1,335 @@
+[
+  {
+    "name": "Google",
+    "founded": "1998-09",
+    "founded_precision": "month",
+    "founded_evidence": {
+      "url": "https://pages.stern.nyu.edu/adamodar/pc/blog/Google10Q3for2015.pdf",
+      "quote": "We were incorporated in California in September 1998 and re-incorporated in the State of Delaware in August",
+      "publisher": "Google Inc., SEC Form 10-Q for the quarter ended 2015-09-30 (PDF copy on the NYU Stern site of Aswath Damodaran; sec.gov returns 403 to the fetcher used)"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "1998-09-04",
+        "url": "https://www.history.co.uk/this-day-in-history/04-september/google-is-incorporated",
+        "quote": "On this day in 1998, search engine firm Google, co-founded by Larry Page and Sergey Brin, who met at Stanford University, files for incorporation in California.",
+        "what_it_represents": "day the incorporation paperwork was filed with the California Secretary of State; secondary source only"
+      },
+      {
+        "date": "1998-08",
+        "url": "https://about.google/company-info/our-story/",
+        "quote": "In August 1998, Sun co-founder Andy Bechtolsheim wrote Larry and Sergey a check for $100,000, and Google Inc. was officially born.",
+        "what_it_represents": "Google's own narrative founding moment, one month EARLIER than its own SEC-filed incorporation month. First-party but inconsistent with the filing record."
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "Alphabet Inc.",
+    "country": "United States",
+    "notes": "Four candidate anchors exist and Google uses two of them: the 1996 Stanford BackRub project, 1998-08 (Bechtolsheim cheque, per about.google), 1998-09 (incorporation, per SEC filings), and a 27 September birthday with no legal meaning. The primary quote is verbatim but was truncated mid-sentence by the extraction tool at the word August, so the Delaware reincorporation year is not confirmed verbatim. Google Inc. later became Google LLC (2017) under Alphabet (formed 2015); neither date verified here."
+  },
+  {
+    "name": "Google Research",
+    "founded": null,
+    "founded_precision": null,
+    "founded_evidence": null,
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2000",
+        "url": "https://en.wikipedia.org/wiki/Google_Research",
+        "quote": "Founded: 2000 (2000)",
+        "what_it_represents": "infobox value, explicitly UNCITED in the article, no first-party corroboration found. Must not be treated as sourced."
+      },
+      {
+        "date": "2018-05-07",
+        "url": "https://research.google/blog/introducing-google-ai/",
+        "quote": "we're unifying our efforts under \"Google AI\", which encompasses all the state-of-the-art research happening across Google.",
+        "what_it_represents": "date the research division was rebranded Google AI; the Google Research name was later restored, with no dated first-party source for the restoration"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "Google",
+    "country": "United States",
+    "notes": "DELIBERATE NULL. No citable founding date, first-party or otherwise. research.google, /philosophy and /blog were all checked; the closest first-party statements are 'Google itself began with a research paper, published in 1998' and 'Our ongoing research over the past 25 years', neither of which dates the organisation. Google Research is an organisational label that accreted rather than being founded on a date: renamed to Google AI in 2018-05 and back again, with the Brain team moving into and out of it."
+  },
+  {
+    "name": "Google Brain",
+    "founded": "2011",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://x.company/projects/brain/",
+      "quote": "When the Google Brain team began their work in 2011, AI and machine learning had been making steady but slow progress for many years.",
+      "publisher": "X, the moonshot factory (Alphabet) - first-party, since Brain began as an X project"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2012",
+        "url": "https://x.company/projects/brain/",
+        "quote": "the Brain team decided they were ready to apply their insights across a range of products at Google, so they graduated from X back to Google in late 2012 as part of Google AI.",
+        "what_it_represents": "graduation out of X into a Google organisation; the page header reads 'Graduated to Google/2012'"
+      }
+    ],
+    "status": "merged",
+    "status_date": "2023-04-20",
+    "status_evidence": {
+      "url": "https://deepmind.google/blog/announcing-google-deepmind/",
+      "quote": "DeepMind and the Brain team from Google Research will be joining forces as a single, focused unit called Google DeepMind."
+    },
+    "parent_org": "Google",
+    "country": "United States",
+    "notes": "No clean founding event, as suspected when the question was posed. Brain started in 2011 as a part-time research collaboration (Jeff Dean, Greg Corrado, Andrew Ng) inside Google X, much of it in 20-percent time, and became a distinct Google organisation only on graduating from X in late 2012. Even Wikipedia's 2011 infobox value cites a retrospective 2012-06-25 New York Times article. Year precision is the most the evidence supports; any month-precision date for Brain should be treated as fabricated."
+  },
+  {
+    "name": "DeepMind",
+    "founded": "2010-11-15",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://find-and-update.company-information.service.gov.uk/company/07386350",
+      "quote": "FRIARS 2022 LIMITED 23 Sep 2010 - 15 Nov 2010",
+      "publisher": "Companies House, UK government (statutory register), previous-company-names entry for company 07386350"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "2010-09-23",
+        "url": "https://find-and-update.company-information.service.gov.uk/company/07386350",
+        "quote": "Incorporated on 23 September 2010",
+        "what_it_represents": "statutory incorporation of the legal entity, under the shelf-company name FRIARS 2022 LIMITED. 'A legal entity exists', not 'DeepMind exists'."
+      },
+      {
+        "date": "2010-11",
+        "url": "https://en.wikipedia.org/wiki/Google_DeepMind",
+        "quote": "The start-up was founded by Demis Hassabis, Shane Legg and Mustafa Suleyman in November 2010",
+        "what_it_represents": "the founders' public launch of the business under the DeepMind name"
+      },
+      {
+        "date": "2010",
+        "url": "https://deepmind.google/about/",
+        "quote": "DeepMind started in 2010, with an interdisciplinary approach to building general AI systems.",
+        "what_it_represents": "DeepMind's own statement, year precision only; DeepMind itself does not commit to a month"
+      }
+    ],
+    "status": "merged",
+    "status_date": "2023-04-20",
+    "status_evidence": {
+      "url": "https://deepmind.google/blog/announcing-google-deepmind/",
+      "quote": "DeepMind and the Brain team from Google Research will be joining forces as a single, focused unit called Google DeepMind."
+    },
+    "parent_org": "Alphabet Inc.",
+    "country": "United Kingdom",
+    "notes": "CORRECTS A COMMON FRAMING, INCLUDING THE ONE IN THE RESEARCH BRIEF. The September/November distinction runs the opposite way to the usual telling. UK incorporation was 2010-09-23; November is when the already-incorporated shell FRIARS 2022 LIMITED was RENAMED DeepMind Technologies Limited, on 2010-11-15, which is also when the founders publicly launched. FRIARS 2022 LIMITED is a shelf-company naming pattern, so 2010-09-23 may be the shelf company's registration rather than any act by the founders. Curator has therefore taken 2010-11-15 as founded and demoted 2010-09-23 to an alternative, on the ground that it is the first date on which the thing called DeepMind existed. The legal entity 07386350 is still listed Active at Companies House despite the 2023 merger. Google's acquisition was reported 2014-01-26/27; no first-party Google announcement of the date was located, so any day-level acquisition date is press-sourced only."
+  },
+  {
+    "name": "Google DeepMind",
+    "founded": "2023-04-20",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://deepmind.google/blog/announcing-google-deepmind/",
+      "quote": "DeepMind and the Brain team from Google Research will be joining forces as a single, focused unit called Google DeepMind.",
+      "publisher": "Google DeepMind (Demis Hassabis), post dated 2023-04-20"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2023-04-20",
+        "url": "https://blog.google/technology/ai/april-ai-update/",
+        "quote": "This group, called Google DeepMind, will bring together two leading research groups in the AI field: the Brain team from Google Research, and DeepMind.",
+        "what_it_represents": "Sundar Pichai's parallel announcement on the Google company blog, same date, corroborating from the parent's side"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "Alphabet Inc.",
+    "country": "United Kingdom",
+    "notes": "This is the public ANNOUNCEMENT of the merged unit, not a legal incorporation. Both announcements use future tense ('will be joining forces'), so the operational merge completed some time after 2023-04-20 and no completion date was found. Google DeepMind is an internal Alphabet business unit, not a separately incorporated company; the underlying UK entity DeepMind Technologies Limited (07386350) continues to exist. The country value reflects DeepMind's London base and was NOT separately cited; treat as low confidence."
+  },
+  {
+    "name": "Microsoft",
+    "founded": "1975-04-04",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://paulallen.com/Futurist/Microsoft.aspx",
+      "quote": "They started Microsoft together, on April 4, 1975 in Albuquerque, New Mexico.",
+      "publisher": "paulallen.com, official site of Microsoft co-founder Paul Allen"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "1975",
+        "url": "https://news.microsoft.com/facts-about-microsoft/",
+        "quote": "1975 - Microsoft founded",
+        "what_it_represents": "Microsoft's own corporate facts page, year precision only; Microsoft itself does not publish the day here"
+      },
+      {
+        "date": "1981-06-25",
+        "url": "https://news.microsoft.com/facts-about-microsoft/",
+        "quote": "June 25, 1981 - Microsoft incorporates",
+        "what_it_represents": "legal incorporation, six years after the partnership was founded. Anyone conflating founded with incorporated gets 1981."
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "United States",
+    "notes": "Began as a Gates/Allen partnership in Albuquerque and did not incorporate until 1981-06-25, so founded and incorporated differ by six years, unlike most rows here. The 1975-04-04 date is co-founder-attested rather than a filing record; Allen's site and Microsoft's facts page agree on the year but only Allen's site gives the day."
+  },
+  {
+    "name": "Microsoft Research",
+    "founded": "1991",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://www.microsoft.com/en-us/research/about-microsoft-research/",
+      "quote": "since its founding in 1991, Microsoft Research has been committed to an academic research approach",
+      "publisher": "Microsoft Research (first-party About page)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "Microsoft",
+    "country": "United States",
+    "notes": "Year precision only; the first-party page gives no month or day. Microsoft Research has been reorganised several times, including being folded into a combined AI and Research group, but no dated first-party source for any reorganisation was located, so no status change is asserted."
+  },
+  {
+    "name": "NVIDIA",
+    "founded": "1993-04-05",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://www.nvidia.com/en-us/about-nvidia/corporate-timeline/",
+      "quote": "Founded on April 5, 1993, by Jensen Huang, Chris Malachowsky, and Curtis Priem, with a vision to bring 3D graphics to the gaming and multimedia markets.",
+      "publisher": "NVIDIA Corporation (official corporate timeline)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "United States",
+    "notes": "First-party, day precision, no conflicting dates encountered. The quoted text is a timeline entry rather than a full grammatical sentence, reproduced verbatim."
+  },
+  {
+    "name": "Amazon",
+    "founded": "1994",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://s2.q4cdn.com/299287126/files/doc_financials/annual/123197_10k.pdf",
+      "quote": "Amazon.com was incorporated in 1994 in the State of Washington and reincorporated in 1996 in Delaware.",
+      "publisher": "Amazon.com, Inc., SEC Form 10-K for FY1997, on Amazon's own investor-relations CDN"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "1994-07-05",
+        "url": "https://www.history.com/this-day-in-history/july-5/amazon-is-founded-by-jeff-bezos",
+        "quote": "On July 5, 1994, Princeton graduate and entrepreneur Jeff Bezos founds Cadabra-a twist on the magic word \"Abracadabra\"-which is initially just an online bookstore run out of his garage in Bellevue, Washington.",
+        "what_it_represents": "day of Washington State incorporation, under the original name Cadabra, Inc. Amazon was NOT named Amazon at this point. Secondary source only."
+      },
+      {
+        "date": "1995-07",
+        "url": "https://s2.q4cdn.com/299287126/files/doc_financials/annual/123197_10k.pdf",
+        "quote": "Since opening for business as \"Earth's Biggest Bookstore\" in July 1995, Amazon.com has become one of the most widely known, used and cited commerce sites on the World Wide Web.",
+        "what_it_represents": "commercial launch of the website, a year after incorporation; aboutamazon.com editorial pages tend to foreground this date instead"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "United States",
+    "notes": "Amazon's own materials are internally inconsistent: SEC filings say incorporated 1994 in Washington, while aboutamazon.com leads with July 1995 site launch. The 1994-07-05 incorporation was under the name Cadabra, Inc. The 1997 10-K is the strongest first-party evidence found but supports only year precision."
+  },
+  {
+    "name": "IBM",
+    "founded": "1911-06-16",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://www.ibm.com/history/ctr-and-ibm",
+      "quote": "June 16, 1911, when C-T-R was officially incorporated as a holding company to control the three separate firms.",
+      "publisher": "IBM (official IBM History site), fetched via the pure.md text proxy because ibm.com returns 403 to the fetcher used"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "1924",
+        "url": "https://www.ibm.com/history/ctr-and-ibm",
+        "quote": "Watson renamed C-T-R with the more expansive moniker of International Business Machines in 1924.",
+        "what_it_represents": "date the company took the IBM name. Anyone dating 'IBM' rather than 'the company that became IBM' gets 1924."
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "United States",
+    "notes": "The 1911 entity was the Computing-Tabulating-Recording Company, formed by Charles Flint as a holding company merging the International Time Recording Company, the Computing Scale Company and the Tabulating Machine Company. So IBM's founding is itself a merger of three older firms, each with an earlier founding date; Hollerith's Tabulating Machine Company is the oldest. IBM dates itself to 1911-06-16 and adopted the IBM name in 1924."
+  },
+  {
+    "name": "Cambridge Research Laboratory",
+    "founded": "1987",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://www.bitsavers.org/pdf/dec/tech_reports/CRL-99-6.pdf",
+      "quote": "The Cambridge Research Laboratory was founded in 1987 to advance the state of the art in both core computing and human-computer interaction, and to use the knowledge so gained to support the Company's corporate objectives.",
+      "publisher": "Compaq Computer Corporation, Cambridge Research Laboratory Technical Report CRL-99-6, 1999-09-17 (standing boilerplate in the CRL technical report series; PDF mirrored at bitsavers.org)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "1987",
+        "url": "https://www.hpcwire.com/2000/12/08/compaq-announces-cambridge-research-laboratory/",
+        "quote": "Founded in 1987, CRL has a team of more than 30 researchers, supported by advanced engineering and business development staff...",
+        "what_it_represents": "corroboration from a Compaq press announcement of 2000-12-08 for the grand opening of CRL's new facility at One Cambridge Center; confirms 1987 is Compaq's own figure, not a later reconstruction"
+      }
+    ],
+    "status": "defunct",
+    "status_date": null,
+    "status_evidence": {
+      "url": "https://en.wikipedia.org/wiki/HP_Labs",
+      "quote": "Cambridge, Massachusetts, United States (also known as CRL, a former DEC research lab)"
+    },
+    "parent_org": "Hewlett-Packard",
+    "country": "United States",
+    "notes": "CRITICAL: this lab was NOT founded by Compaq, despite appearing in the Epoch dump as 'Compaq CRL'. Digital Equipment Corporation founded it in 1987 as DEC's Cambridge Research Laboratory; the Computer History Museum's CRL collection covers 1987-1994 and describes it as DEC's. It became Compaq's when Compaq acquired DEC in 1998 and HP's when HP acquired Compaq. The DEC-to-Compaq closing date was NOT verified: a DEC Form 8-K of 1998-06-08 says only that the parties 'expect the transaction to close shortly after the special meeting' scheduled 1998-06-11, so the widely cited 1998-06-11 completion is unconfirmed. HP's own timeline confirms the HP-Compaq step on 2002-05-03. The CRL/DEC technical report series runs 1990-2002 and stops; Wikipedia lists Cambridge, Massachusetts among FORMER HP Labs sites. No citable closure date was found, so status_date is deliberately null. If a date is needed for 'ceased to be Compaq CRL', 2002-05-03 is the defensible one."
+  },
+  {
+    "name": "Mitsubishi Electric Research Laboratories",
+    "founded": "1991",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://www.merl.com/company/history",
+      "quote": "In 1991, Mitsubishi Electric's Corporate Research and Development organization (CR&D) opened MERL in Cambridge, Mass., under the leadership of Dr. Tohei Nitta and Dr. Laszlo (Les) Belady.",
+      "publisher": "Mitsubishi Electric Research Laboratories (official company history page)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "1996",
+        "url": "https://www.merl.com/company/history",
+        "quote": "In 1995, CR&D decided to combine HRI and ATL together into a new organization called Mitsubishi Electric Information Technology Center America (ITA). The next year, MERL was merged into ITA as well.",
+        "what_it_represents": "MERL absorbed into ITA in 1996, so the MERL name did not exist as a standalone organisation between 1996 and 2000"
+      },
+      {
+        "date": "2000",
+        "url": "https://www.merl.com/company/history",
+        "quote": "In 2000, the staff in Waltham moved to Cambridge, and ITA returned to the name MERL.",
+        "what_it_represents": "restoration of the MERL name after the ITA period; a refounding of the brand, though MERL claims organisational continuity from 1991"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "Mitsubishi Electric Corporation",
+    "country": "United States",
+    "notes": "A US-based Cambridge, Massachusetts subsidiary lab of a Japanese parent, so country is the lab's location, not the parent's. The MERL name has a four-year gap (1996-2000) when the organisation was called ITA, which matters when matching on organisation name across a time series. Laszlo Belady's name carries an accent on the source page; transliterated to ASCII."
+  }
+]

--- a/data/enrichment/frontier_labs/research/batch2.json
+++ b/data/enrichment/frontier_labs/research/batch2.json
@@ -1,0 +1,378 @@
+[
+  {
+    "name": "OpenAI",
+    "founded": "2015-12",
+    "founded_precision": "month",
+    "founded_evidence": {
+      "url": "https://en.wikipedia.org/wiki/OpenAI",
+      "quote": "In December 2015, OpenAI was founded as the nonprofit organization OpenAI, Inc.",
+      "publisher": "Wikipedia"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "2015-12-11",
+        "url": "https://techcrunch.com/2015/12/11/non-profit-openai-launches-with-backing-from-elon-musk-and-sam-altman/",
+        "quote": "Today, OpenAI, a nonprofit artificial intelligence research company was announced to the world.",
+        "what_it_represents": "public announcement; the sentence says 'Today' and the day comes from the article dateline of 2015-12-11"
+      },
+      {
+        "date": "2015-12-08",
+        "what_it_represents": "Delaware incorporation of OpenAI, Inc. per Wikipedia's infobox, which cites OpenCorporates. UNVERIFIED: opencorporates.com returned a CAPTCHA, sec.gov returned 403, and the musk-v-altman complaint PDFs could not be text-extracted. No quote is given because no page carrying this date was successfully read."
+      },
+      {
+        "date": "2015",
+        "url": "https://news.delaware.gov/2025/10/28/ag-jennings-completes-review-of-openai-recapitalization/",
+        "quote": "OpenAI, Inc. was incorporated as a Delaware nonprofit corporation in 2015",
+        "what_it_represents": "the Delaware Attorney General's own characterisation of the original incorporation, year precision. The strongest official confirmation obtained."
+      },
+      {
+        "date": "2019-03-11",
+        "url": "https://medium.com/syncedreview/openai-establishes-for-profit-company-9d595cc5f3c9",
+        "quote": "OpenAI today announced the creation of a new for-profit company",
+        "what_it_represents": "creation of the capped-profit OpenAI LP under the nonprofit"
+      }
+    ],
+    "status": "active",
+    "status_date": "2025-10-28",
+    "status_evidence": {
+      "url": "https://www.delawareinc.com/blog/openai-is-now-a-pbc/",
+      "quote": "On October 28, 2025, at 8:07 a.m. the Delaware Division of Corporation approved a 30-page Certificate of Incorporation (COI) for OPENAI GROUP PBC"
+    },
+    "parent_org": null,
+    "country": "United States",
+    "notes": "Founding is genuinely ill-defined: Delaware incorporation of the nonprofit (reported 2015-12-08, unverified), public announcement (2015-12-11, well sourced), then two structural events -- OpenAI LP capped-profit (2019-03-11) and recapitalisation into OpenAI Group PBC (2025-10-28). openai.com returns 403 to the fetcher and web.archive.org was blocked, so no OpenAI first-party page could be read. Status left active: the entity continues, restructured."
+  },
+  {
+    "name": "Anthropic",
+    "founded": "2021-01",
+    "founded_precision": "month",
+    "founded_evidence": {
+      "url": "https://en.wikipedia.org/wiki/Anthropic",
+      "quote": "Anthropic was founded in January 2021",
+      "publisher": "Wikipedia"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "2021-01-26",
+        "url": "https://www.highergov.com/awardee/anthropic-pbc-782300426/",
+        "quote": "Jan. 26, 2021",
+        "what_it_represents": "Date Founded field in HigherGov's US federal awardee record for Anthropic PBC; matches Wikipedia's infobox, which cites OpenCorporates for the Delaware entity"
+      },
+      {
+        "date": "2021-02-03",
+        "url": "https://www.bizprofile.net/ca/san-francisco/anthropic-inc",
+        "quote": "Officially filed on February 3, 2021, this corporation is recognized under the document number 4688086.",
+        "what_it_represents": "California Secretary of State filing, a separate later act from the Delaware formation. Not in conflict; a different event."
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "United States",
+    "notes": "anthropic.com/company was fetched and contains no founding date, so no first-party date exists to cite. The day-precision 2021-01-26 rests on HigherGov and on OpenCorporates via Wikipedia's infobox; opencorporates.com itself returned a CAPTCHA and could not be verified directly. Month precision is what the readable evidence supports."
+  },
+  {
+    "name": "xAI",
+    "founded": "2023-03-09",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://www.ktnv.com/news/elon-musk-files-nevada-business-formation-for-x-ai",
+      "quote": "The filing was from March 9, 2023.",
+      "publisher": "KTNV Las Vegas (Scripps), reporting from Nevada Secretary of State business records"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "2023-03-09",
+        "url": "https://en.wikipedia.org/wiki/XAI_(company)",
+        "quote": "Elon Musk founded xAI on March 9, 2023.",
+        "what_it_represents": "incorporation of X.AI Corp. in Nevada"
+      },
+      {
+        "date": "2023-07-12",
+        "url": "https://en.wikipedia.org/wiki/XAI_(company)",
+        "quote": "Musk announced xAI on July 12, 2023.",
+        "what_it_represents": "public announcement of the company and founding technical team, four months after incorporation"
+      }
+    ],
+    "status": "merged",
+    "status_date": "2025-03-28",
+    "status_evidence": {
+      "url": "https://en.wikipedia.org/wiki/XAI_(company)",
+      "quote": "On March 28, 2025, Musk announced that xAI acquired sister company X Corp., the developer of social media platform X."
+    },
+    "parent_org": null,
+    "country": "United States",
+    "notes": "x.ai returns 403 to the fetcher, so no first-party page was read. The Nevada filing date is corroborated by a local outlet that inspected the Secretary of State record; the record itself was not reached. Status merged reflects xAI acquiring X Corp. in an all-stock deal placing both under a holding company; xAI is the surviving AI operation, not the acquired party, but the corporate perimeter changed materially."
+  },
+  {
+    "name": "Meta AI",
+    "founded": "2013-12",
+    "founded_precision": "month",
+    "founded_evidence": {
+      "url": "https://www.forbes.com/sites/richardnieva/2023/11/30/meta-ai-yann-lecun-fair-10th-anniversary/",
+      "quote": "Zuckerberg and former Facebook CTO Mike Schroepfer launched FAIR in December 2013, tapping LeCun, a professor of computer science at NYU, to lead the project.",
+      "publisher": "Forbes"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2013",
+        "url": "https://ai.meta.com/blog/fair-10-year-anniversary-open-science-meta/",
+        "quote": "The launch of FAIR dates back to late 2013.",
+        "what_it_represents": "Meta's own statement, year precision only. Meta does not publish a day."
+      },
+      {
+        "date": "2013-12-09",
+        "url": "https://techcrunch.com/2013/12/09/facebook-artificial-intelligence-lab-lecun/",
+        "quote": "So today the company announced that one of the world's leading deep learning and machine learning scientists, NYU's Professor Yann LeCun, will lead its new artificial intelligence laboratory.",
+        "what_it_represents": "public announcement of the lab and of LeCun as its head; the sharpest dated public event"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "Meta Platforms",
+    "country": "United States",
+    "notes": "FAIR has no incorporation date; it is an internal research division, so founding means when the lab was stood up, which is inherently fuzzy. Meta's own blog says only 'late 2013'. The same TechCrunch piece notes MIT Technology Review first reported the lab in September, so internal formation predates the announcement. Later renamed from Facebook AI Research to Fundamental AI Research; no citable date for that rename was found."
+  },
+  {
+    "name": "Meta Platforms",
+    "founded": "2004-02-04",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://en.wikipedia.org/wiki/Meta_Platforms",
+      "quote": "February 4, 2004; 22 years ago (2004-02-04) in Cambridge, Massachusetts, U.S.",
+      "publisher": "Wikipedia (infobox)"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "2004",
+        "url": "https://www.meta.com/about/company-info/",
+        "quote": "When Facebook launched in 2004, it changed the way that people connect.",
+        "what_it_represents": "Meta's own company-info page, year precision only; Meta does not publish a founding day"
+      },
+      {
+        "date": "2004-07",
+        "what_it_represents": "Delaware incorporation, separately reported as July 2004 in Meta's SEC 10-K filings. UNVERIFIED: sec.gov returns 403 to the fetcher and Meta's own annual-report PDF could not be text-extracted, so no verbatim quote exists. No quote is given rather than repeating one that does not carry this date."
+      }
+    ],
+    "status": "renamed",
+    "status_date": "2021-10-28",
+    "status_evidence": {
+      "url": "https://en.wikipedia.org/wiki/Meta_Platforms",
+      "quote": "The metaverse vision and the name change from Facebook, Inc. to Meta Platforms was introduced at Facebook Connect on October 28, 2021."
+    },
+    "parent_org": null,
+    "country": "United States",
+    "notes": "Originally established as TheFacebook, Inc. Meta's own newsroom post on the rename is date-stamped 2021-10-28 but its prose says 'Today at Connect 2021' rather than the explicit date, so the Wikipedia sentence carrying the date inline is used instead. Three distinct dates: 2004-02-04 (TheFacebook launched, Cambridge MA), July 2004 (Delaware incorporation, unverified), 2021-10-28 (rename)."
+  },
+  {
+    "name": "Inflection AI",
+    "founded": "2022",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://en.wikipedia.org/wiki/Inflection_AI",
+      "quote": "founded in 2022",
+      "publisher": "Wikipedia"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "2022-03",
+        "url": "https://www.theregister.com/2022/03/09/linkedin_hoffman_ai/",
+        "quote": "LinkedIn co-founder Reid Hoffman, DeepMind co-founder Mustafa Suleyman, and ex-DeepMind AI expert Karen Simonyan announced on Tuesday a new venture of theirs named Inflection AI.",
+        "what_it_represents": "public announcement; the sentence says 'on Tuesday' and the article dateline of 2022-03-09 makes that Tuesday 2022-03-08"
+      }
+    ],
+    "status": "active",
+    "status_date": "2024-03-19",
+    "status_evidence": {
+      "url": "https://blogs.microsoft.com/blog/2024/03/19/mustafa-suleyman-deepmind-and-inflection-co-founder-joins-microsoft-to-lead-copilot/",
+      "quote": "Mustafa Suleyman and Karen Simonyan are joining Microsoft to form a new organization called Microsoft AI"
+    },
+    "parent_org": null,
+    "country": "United States",
+    "notes": "Status is active, NOT acquired: Microsoft hired the founders and most staff and paid a licensing fee rather than buying the company; the entity continued under a new CEO with a B2B model. The widely reported 650 million USD figure and headcount are deliberately NOT recorded, because Microsoft's post does not state them and no filing was read. Karen Simonyan's name carries an accent in the sources; transliterated to ASCII."
+  },
+  {
+    "name": "AI21 Labs",
+    "founded": "2017",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://research.contrary.com/company/ai21-labs",
+      "quote": "AI21 Labs was founded in 2017 in Israel.",
+      "publisher": "Contrary Research"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "2017-11",
+        "url": "https://en.wikipedia.org/wiki/AI21_Labs",
+        "quote": "AI21 Labs was founded in November 2017 by Yoav Shoham, Ori Goshen, and Amnon Shashua in Tel Aviv, Israel.",
+        "what_it_represents": "month precision, but WEAKLY SOURCED: the researcher followed Wikipedia's cited source through to the Globes article on AI21's 35 million USD raise, and that page contains NO founding date at all. So Wikipedia's own citation does not support its month. Curator downgraded founded to year precision for this reason."
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "Israel",
+    "notes": "CURATOR DOWNGRADE. The researcher reported 2017-11 at month precision; that has been reduced to 2017 at year precision, because following Wikipedia's citation through disproved the support for the month. The year is solid, corroborated independently. startupnationcentral.org returned 403 and no first-party AI21 page giving a founding date was located. This row is a worked example of why evidence_strength grades source class: a confident-sounding month with a citation that does not check out is weaker than a plain year that does."
+  },
+  {
+    "name": "Technology Innovation Institute",
+    "founded": "2020",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://www.tii.ae/news/abu-dhabi-unveils-pioneering-global-center-advanced-technology-research",
+      "quote": "Teams of international scientists and researchers joined the institute from around the world within two months of the first board meeting in August 2020.",
+      "publisher": "Technology Innovation Institute (first-party newsroom)"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "2020-08",
+        "url": "https://www.tii.ae/news/abu-dhabi-unveils-pioneering-global-center-advanced-technology-research",
+        "quote": "Teams of international scientists and researchers joined the institute from around the world within two months of the first board meeting in August 2020.",
+        "what_it_represents": "first board meeting, the earliest concretely dated institutional event, first-party"
+      },
+      {
+        "date": "2020-11-10",
+        "url": "https://www.tii.ae/news/abu-dhabi-unveils-pioneering-global-center-advanced-technology-research",
+        "quote": "Abu Dhabi has unveiled the Technology Innovation Institute (TII), the dedicated applied research pillar of the Advanced Technology Research Council (ATRC), committed to reinforcing Abu Dhabi and the UAE's status as a global hub for innovation and advanced technologies.",
+        "what_it_represents": "public unveiling; the date is the page's dateline of 2020-11-10"
+      },
+      {
+        "date": "2020-05",
+        "what_it_represents": "Wikipedia's claimed founding month. UNVERIFIED: the researcher tried three times to reach the cited BusinessWire source (two timeouts, one ECONNRESET) and could not confirm that May 2020 appears in it. No quote given."
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "Advanced Technology Research Council",
+    "country": "United Arab Emirates",
+    "notes": "A government-established research institute with no incorporation record, so founding is ill-defined. tii.ae/about-us contains no founding date. Three candidates: May 2020 (unverified), August 2020 (first board meeting, first-party), 2020-11-10 (public unveiling, first-party). Year precision because the month cannot be honestly resolved from what was read. TII is the lab behind the Falcon model family."
+  },
+  {
+    "name": "NAVER",
+    "founded": "1999-06",
+    "founded_precision": "month",
+    "founded_evidence": {
+      "url": "https://www.navercorp.com/en/company/history",
+      "quote": "1999 (June): NAVER.com incorporated and launched Search Portal 'NAVER'",
+      "publisher": "NAVER Corporation (first-party history timeline)"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "1999-06-02",
+        "url": "https://en.wikipedia.org/wiki/Naver_Corporation",
+        "quote": "June 2, 1999; 27 years ago (1999-06-02)",
+        "what_it_represents": "day-precision incorporation from the infobox; the article body says only 'in 1999' and provides no fetchable reference for the day, so the day is unverified"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "South Korea",
+    "notes": "Month precision is first-party-solid from NAVER's own history timeline. The company originated as an in-house venture inside Samsung SDS before spinning out; no citable date for that internal origin was found. Original entity name was Naver Comm."
+  },
+  {
+    "name": "NAVER AI Lab",
+    "founded": null,
+    "founded_precision": null,
+    "founded_evidence": null,
+    "founded_contested": false,
+    "founded_alternatives": [],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "NAVER Cloud",
+    "country": "South Korea",
+    "notes": "NULL BY DESIGN. NAVER's own careers page for the lab states its mission and research fields but gives no founding date of any kind. Searches surfaced only adjacent, differently-scoped facts -- CLOVA platform introduced 2017-03, HyperCLOVA launched 2021-05, CLOVA integrated into NAVER Cloud in 2023 -- and no source stating when NAVER AI Lab itself was established, nor any documenting a rename from Clova AI Research. Reporting a date here would be reconstruction.",
+    "sources_extra": ["https://naver-career.github.io/en/teams/naver-ai-lab/"]
+  },
+  {
+    "name": "NAVER Cloud",
+    "founded": "2009-05-01",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://www.navercloudcorp.com/en/info/",
+      "quote": "Date of Establishment: May 1, 2009",
+      "publisher": "NAVER Cloud Corporation (first-party)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2020",
+        "url": "https://www.navercloudcorp.com/en/info/",
+        "quote": "Changed the company name to NAVER Cloud",
+        "what_it_represents": "rename from NAVER Business Platform; the year comes from the timeline's structure rather than from prose containing it"
+      }
+    ],
+    "status": "renamed",
+    "status_date": "2020",
+    "status_evidence": {
+      "url": "https://www.navercloudcorp.com/en/info/",
+      "quote": "Changed the company name to NAVER Cloud"
+    },
+    "parent_org": "NAVER",
+    "country": "South Korea",
+    "notes": "Founded as NAVER Business Platform on 2009-05-01 per the company's own info page; renamed NAVER Cloud in 2020. HyperCLOVA X and NAVER's AI product work sit under this entity. The rename year is weaker than the establishment date because it comes from page structure rather than prose."
+  },
+  {
+    "name": "Baidu",
+    "founded": "2000-01-18",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://en.wikipedia.org/wiki/Baidu",
+      "quote": "Baidu was incorporated on 18 January 2000 by Robin Li and Eric Xu.",
+      "publisher": "Wikipedia"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2000-01",
+        "url": "https://www.ebsco.com/research-starters/history/baidu-inc",
+        "quote": "Li and Xu went to China and founded Baidu in January 2000 to provide search services to portals in China.",
+        "what_it_represents": "month-precision corroboration from an independent reference publisher"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "China",
+    "notes": "The day refers to incorporation of Baidu, Inc. in the Cayman Islands. The researcher tried four times to reach Baidu's own 20-F filings on ir.baidu.com for the first-party incorporation language (three timeouts, one ECONNRESET) and sec.gov returns 403, so the day rests on Wikipedia plus an independent month-precision corroboration rather than the filing. Operations began in Beijing; the Cayman entity is the listed holding company."
+  },
+  {
+    "name": "Baidu Research",
+    "founded": "2014-05-16",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://www.prnewswire.com/news-releases/baidu-opens-silicon-valley-lab-appoints-andrew-ng-as-head-of-baidu-research-259539471.html",
+      "quote": "Baidu, Inc. (NASDAQ: BIDU), the leading Chinese language Internet search provider, today announced the appointment of pioneering Artificial Intelligence (AI) researcher Andrew Ng as Chief Scientist of Baidu. Mr. Ng will lead Baidu Research, with labs in Beijing and Silicon Valley.",
+      "publisher": "PR Newswire, release issued by Baidu, Inc. (first-party), dateline 2014-05-16"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "2013",
+        "what_it_represents": "Baidu's Institute of Deep Learning, the predecessor lab folded into Baidu Research, is widely reported as established in 2013. UNVERIFIED: research.baidu.com serves only a maintenance notice and Wikipedia's Baidu article does not mention IDL at all. No quote given rather than attaching one that does not carry this date."
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "Baidu",
+    "country": "China",
+    "notes": "An internal division with no incorporation record, assembled around a pre-existing lab rather than created from nothing. 2014-05-16 is the day Baidu itself named and launched Baidu Research publicly, at the grand opening of its Sunnyvale R&D centre; the release describes Baidu Research as comprising the Silicon Valley AI Lab, the Beijing Deep Learning Lab and the Beijing Big Data Lab. research.baidu.com was fetched twice and returned only a maintenance notice."
+  }
+]

--- a/data/enrichment/frontier_labs/research/batch3.json
+++ b/data/enrichment/frontier_labs/research/batch3.json
@@ -1,0 +1,281 @@
+[
+  {
+    "name": "Mistral AI",
+    "founded": "2023-04-28",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://recherche-entreprises.api.gouv.fr/search?q=mistral%20ai",
+      "quote": "\"date_creation\": \"2023-04-28\"",
+      "publisher": "Annuaire des Entreprises / recherche-entreprises API, DINUM, French government; SIREN 952418325, nom_complet MISTRAL AI"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2023-04",
+        "url": "https://en.wikipedia.org/wiki/Mistral_AI",
+        "quote": "Mistral AI was established in April 2023 by three French AI researchers",
+        "what_it_represents": "month-precision founding in prose; consistent with the registry date"
+      },
+      {
+        "date": "2023-09-27",
+        "url": "https://mistral.ai/news/about-mistral-ai/",
+        "quote": "Bringing open AI models to the frontier",
+        "what_it_represents": "first-party public launch; earliest post on Mistral's news page, dated 2023-09-27. Company existed ~5 months before this."
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "France",
+    "notes": "Strongest evidence in this batch: a government company register, not journalism. SIREN 952418325, legal form SAS, registered office Paris. A separate shell MISTRAL AI RESERVED (SIREN 992519694) exists and must not be confused with the operating company. A decoy SIREN 952481660 appears in some secondary write-ups and is wrong. Mistral's own site carries no founding-date statement."
+  },
+  {
+    "name": "Cohere",
+    "founded": "2019",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://cohere.com/about",
+      "quote": "Cohere was founded in 2019 in Toronto with a bold vision: to do whatever it takes to scale intelligence to serve humanity.",
+      "publisher": "Cohere Inc. (first-party)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "Canada",
+    "notes": "First-party but year precision only; no month or incorporation date published, no Canadian register record retrieved."
+  },
+  {
+    "name": "Stability AI",
+    "founded": "2019-11-04",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://find-and-update.company-information.service.gov.uk/company/12295325",
+      "quote": "Incorporated on 4 November 2019",
+      "publisher": "Companies House, GOV.UK; STABILITY AI LTD, company number 12295325"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2019",
+        "url": "https://en.wikipedia.org/wiki/Stability_AI",
+        "quote": "Stability AI was founded in 2019 by Emad Mostaque and Cyrus Hodes.",
+        "what_it_represents": "year-precision prose; agrees with the register"
+      },
+      {
+        "date": "2019-11-04",
+        "url": "https://find-and-update.company-information.service.gov.uk/company/12295325/officers",
+        "quote": "MOSTAQUE, Mohammad Emad - Appointed 4 November 2019",
+        "what_it_represents": "corroborates entity identity: directorship starts on the incorporation date; he resigned 2024-03-22"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "United Kingdom",
+    "notes": "The 2019 incorporation is real but misleading for cross-lab comparison: Stability had essentially no public AI-lab activity until 2021-2022 (Stable Diffusion released 2022-08), so a reader comparing founded dates will over-age Stability by ~3 years. Companies House lists no previous names for 12295325. Cyrus Hodes's co-founder status was later litigated. A separate US entity Stability AI Inc. exists; no registration date retrieved."
+  },
+  {
+    "name": "Safe Superintelligence Inc",
+    "founded": "2024-06-19",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://en.wikipedia.org/wiki/Safe_Superintelligence_Inc.",
+      "quote": "On June 19, 2024, Sutskever posted on X that he was starting SSI Inc, with the goal to safely develop superintelligent AI",
+      "publisher": "Wikipedia"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2024-06-19",
+        "url": "https://time.com/6990076/safe-superintelligence-inc-announced/",
+        "quote": "he's launching a new venture dubbed Safe Superintelligence Inc.",
+        "what_it_represents": "public announcement; article dateline 2024-06-19"
+      },
+      {
+        "date": "2024",
+        "url": "https://ssi.inc/",
+        "quote": "Safe Superintelligence Inc. (c) 2024 - 2026",
+        "what_it_represents": "first-party copyright range, lower-bounding existence to 2024"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "United States",
+    "notes": "This is the public ANNOUNCEMENT date, not a verified incorporation date. No Delaware or other registry record retrieved; actual incorporation may predate it by weeks or months. Offices in Palo Alto and Tel Aviv, so country is arguably dual. Reuters, AP, The Verge and NYT cited by Wikipedia for the same date were not fetchable."
+  },
+  {
+    "name": "Allen Institute for AI",
+    "founded": "2014",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://allenai.org/about",
+      "quote": "Philanthropist and Microsoft co-founder Paul Allen founded Ai2 in 2014 to find transformative ways to develop AI to address some of the world's biggest challenges.",
+      "publisher": "Allen Institute for AI (first-party)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2014",
+        "url": "https://en.wikipedia.org/wiki/Allen_Institute_for_AI",
+        "quote": "founded by late Microsoft co-founder and philanthropist Paul Allen in 2014",
+        "what_it_represents": "cites allenai.org/about as its source, so NOT independent corroboration"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "United States",
+    "notes": "Secondary aggregators claim 2014-01-01 and that Oren Etzioni was appointed 2013-09, but no citable page carrying that day-precision date was fetched (GeekWire returned 403), so it is deliberately NOT reported. 501(c)(3) non-profit, Seattle. Rebranded in presentation from AI2 to Ai2."
+  },
+  {
+    "name": "EleutherAI",
+    "founded": "2020-07",
+    "founded_precision": "month",
+    "founded_evidence": {
+      "url": "https://www.eleuther.ai/about",
+      "quote": "Founded in July 2020 by Connor Leahy, Sid Black, and Leo Gao, EleutherAI has grown from a Discord server for talking about GPT-3 to a leading non-profit research institute focused on large-scale artificial intelligence research.",
+      "publisher": "EleutherAI (first-party)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2023-03-02",
+        "url": "https://blog.eleuther.ai/year-two-preface/",
+        "quote": "we are thrilled to announce that we are forming a non-profit research institute, and we are excited to be able to say that over twenty of our regular contributors are now working full-time doing research.",
+        "what_it_represents": "formation of the EleutherAI Institute as a formal non-profit; post dated 2023-03-02. Says 'we are forming', so legal incorporation date is announced-adjacent, not stated."
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": null,
+    "notes": "Founding genuinely ill-defined. 2020-07 is the creation of a Discord server by volunteers: no legal entity, no incorporation, no premises, no employees. A formal non-profit was announced 2023-03-02, ~32 months later; exact incorporation date and jurisdiction not found, so country is null rather than guessed. Source page writes GPT-3 with a non-breaking hyphen (U+2011); rendered ASCII."
+  },
+  {
+    "name": "Hugging Face",
+    "founded": "2016",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://en.wikipedia.org/wiki/Hugging_Face",
+      "quote": "The company was founded in 2016 by French entrepreneurs Clement Delangue, Julien Chaumond, and Thomas Wolf in New York City",
+      "publisher": "Wikipedia"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2016",
+        "url": "https://www.forbes.com/companies/hugging-face/",
+        "quote": "Founded 2016",
+        "what_it_represents": "Forbes company-profile data field, independent of Wikipedia"
+      },
+      {
+        "date": "2017-03-09",
+        "url": "https://techcrunch.com/2017/03/09/hugging-face-wants-to-become-your-artificial-bff/",
+        "quote": "have raised $1.2 million from Betaworks, SV Angel and NBA star Kevin Durant and others",
+        "what_it_represents": "Wikipedia's cited source for the founding claim. On fetching, it does NOT state a founding date; it only references a 2016-09 private beta, which upper-bounds founding at 2016."
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "United States",
+    "notes": "Weakest citation chain among the independent companies here. No first-party page stating a founding year could be located. The 2016 figure rests on Wikipedia plus a Forbes data field, and following Wikipedia's own citation through does not confirm it. Clement is spelled with an acute accent in sources; rendered ASCII. Founded in New York City as a teen chatbot app; pivoted to ML infrastructure around 2018."
+  },
+  {
+    "name": "Reka AI",
+    "founded": "2022",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://siliconangle.com/2025/07/22/multimodal-ai-startup-reka-ai-raises-110m-1b-valuation/",
+      "quote": "Founded in 2022, Reka develops multimodal models focusing on ultra-efficient training and serving infrastructure for delivering inference at low cost.",
+      "publisher": "SiliconANGLE (trade press, 2025-07-22)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2023-06-27",
+        "url": "https://www.reka.ai/news/announcing-our-60m-funding-to-build-generative-models-and-advance-ai-research",
+        "quote": "Today, we emerge from stealth",
+        "what_it_represents": "first-party emergence from stealth, dated 2023-06-27; earliest item on Reka's news index"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "United States",
+    "notes": "No first-party founding date exists on reka.ai: no about page, and the earliest news post does not say when the company started. The 2022 figure comes only from trade-press boilerplate. TRAP AVOIDED: UK Companies House lists REKA AI LTD. (number 14242489, incorporated 2022-07-19, Altrincham, one director, SIC 58290). The date is temptingly close but registered office, size and profile do not match the Sunnyvale/San Francisco lab; that record was NOT used and must not be merged in. Reported funding also disagrees: Reka's own post says $60M, press reported $58M."
+  },
+  {
+    "name": "Character.AI",
+    "founded": "2021-11",
+    "founded_precision": "month",
+    "founded_evidence": {
+      "url": "https://www.forbes.com/sites/kenrickcai/2023/10/11/character-ai-chatbots-group-chat/",
+      "quote": "The pair founded Character.AI in November 2021, a year before public appetite for AI swelled when OpenAI released ChatGPT.",
+      "publisher": "Forbes (Kenrick Cai, 2023-10-11); this is the source Wikipedia cites, followed through"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2021-11",
+        "url": "https://en.wikipedia.org/wiki/Character.ai",
+        "quote": "Character.ai was established in November 2021.",
+        "what_it_represents": "prose whose citation resolves to the Forbes article above"
+      }
+    ],
+    "status": "active",
+    "status_date": "2024-08-02",
+    "status_evidence": {
+      "url": "https://techcrunch.com/2024/08/02/character-ai-ceo-noam-shazeer-returns-to-google/",
+      "quote": "This agreement will provide increased funding for Character.AI to continue growing and to focus on building personalized AI products for users around the world"
+    },
+    "parent_org": null,
+    "country": "United States",
+    "notes": "Legal name Character Technologies, Inc.; Menlo Park, California. The 2024 Google event is a reverse-acquihire, NOT an acquisition: Google hired co-founders Noam Shazeer and Daniel De Freitas plus some staff and took a non-exclusive technology licence, while the company continued independently with Dominic Perella as interim CEO. Status left active for that reason."
+  },
+  {
+    "name": "Adept AI",
+    "founded": null,
+    "founded_precision": null,
+    "founded_evidence": {
+      "url": "https://techcrunch.com/2024/06/28/amazon-hires-founders-away-from-ai-startup-adept/",
+      "quote": "Adept was founded two years ago with the goal of creating an AI model that can perform actions on any software tool using natural language.",
+      "publisher": "TechCrunch (2024-06-28)"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "2022-04-26",
+        "url": "https://techcrunch.com/2022/04/26/2304039/",
+        "quote": "At a product lab called Adept that emerged from stealth today with $65 million in funding...",
+        "what_it_represents": "emergence from stealth / Series A, 2022-04-26. A launch date, NOT a founding date."
+      },
+      {
+        "date": "2022-04-27",
+        "url": "https://www.theregister.com/2022/04/27/adept_ai_google/",
+        "quote": "Adept AI, an artificial intelligence R&D lab founded by ex-Googlers who helped invent the popular transformer architecture, launched on Tuesday with the ambitious goal of teaching machines how to use 'every software tool and API in the world.'",
+        "what_it_represents": "same launch reported one day later; launched on Tuesday = 2022-04-26"
+      }
+    ],
+    "status": "active",
+    "status_date": "2024-06-28",
+    "status_evidence": {
+      "url": "https://techcrunch.com/2024/06/28/amazon-hires-founders-away-from-ai-startup-adept/",
+      "quote": "Adept, a startup developing AI-powered \"agents\" to complete various software-based tasks, has agreed to license its tech to Amazon, and the startup's co-founders and portions of its team have joined the e-commerce giant."
+    },
+    "parent_org": null,
+    "country": "United States",
+    "notes": "FOUNDED SET TO NULL BY THE CURATOR, overriding the researcher's '2022'. That value was an inference from 'founded two years ago' in an article datelined 2024-06-28, not a quoted date. No source literally states Adept's founding date; adept.ai returns 403 so the first-party Introducing Adept post could not be read. Secondary aggregators variously assert 2022-01-05, 2022-01 and 2021; none verifiable, none adopted. Public launch 2022-04-26 is well evidenced and is recorded in founded_alternatives; use that if a date is needed, labelled as a launch. On status: reverse-acquihire, not acquisition. Amazon hired co-founder/CEO David Luan and others and licensed models and datasets, but TechCrunch says 'Adept isn't closing up shop, however', with Zach Brock becoming CEO. Headcount reportedly fell from ~100 to ~20. parent_org null because no equity acquisition is evidenced."
+  }
+]

--- a/data/enrichment/frontier_labs/research/batch4.json
+++ b/data/enrichment/frontier_labs/research/batch4.json
@@ -1,0 +1,309 @@
+[
+  {
+    "name": "DeepSeek",
+    "founded": "2023-07-17",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://baike.baidu.com/en/item/Hangzhou%20DeepSeek%20Artificial%20Intelligence%20Co.,%20Ltd/978595",
+      "quote": "Hangzhou DeepSeek Artificial Intelligence Co., Ltd. (commonly known as DeepSeek) was founded on July 17, 2023",
+      "publisher": "Baidu Baike (English edition)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2023-07-17",
+        "url": "https://en.wikipedia.org/wiki/DeepSeek",
+        "quote": "On 17 July 2023, that lab was spun off into an independent company.",
+        "what_it_represents": "spin-off of High-Flyer's internal AGI research lab into an independent company"
+      },
+      {
+        "date": "2023",
+        "url": "https://www.forbes.com/sites/tylerroush/2025/01/28/who-is-behind-deepseek-heres-what-to-know-about-founder-liang-wenfeng/",
+        "quote": "Liang founded DeepSeek in 2023, and the company relied on maximizing the output of processors available in China",
+        "what_it_represents": "year-only corroboration"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "High-Flyer",
+    "country": "China",
+    "notes": "Owned and funded by the quantitative hedge fund High-Flyer; Liang Wenfeng is CEO of both. High-Flyer's own founding is contested because two legal entities exist: Zhejiang High-Flyer Asset Management Co., Ltd. (2015) and Ningbo High-Flyer Quant Investment Management Partnership LLP (2016), the latter now doing business as High-Flyer. The first-party page high-flyer.cn/en/about returned 404, so no first-party confirmation. The registered DeepSeek entity appears in sources as both 'Hangzhou DeepSeek Artificial Intelligence Co., Ltd.' and 'Hangzhou DeepSeek Artificial Intelligence Basic Technology Research Co., Ltd.'"
+  },
+  {
+    "name": "Alibaba DAMO Academy",
+    "founded": "2017-10",
+    "founded_precision": "month",
+    "founded_evidence": {
+      "url": "https://baike.baidu.com/en/item/Damo%20Academy/653561",
+      "quote": "In October 2017, the Damo Academy was established, dedicated to exploring the unknown in science and technology and conducting research in basic science and innovative technologies.",
+      "publisher": "Baidu Baike (English edition)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2017-10-11",
+        "url": "https://en.people.cn/n3/2017/1012/c90000-9278941.html",
+        "quote": "The Alibaba Group announced Wednesday it will set up a new research institute and invest over 100 billion yuan (about 15 billion U.S. dollars) over the next three years in advanced technology development.",
+        "what_it_represents": "announcement at The Computing Conference 2017 in Hangzhou, Wednesday 2017-10-11"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "Alibaba Group",
+    "country": "China",
+    "notes": "Founding here means public establishment of an internal Alibaba unit at the Computing Conference on 2017-10-11; there is no incorporation date. First-party attempts all failed: damo.alibaba.com/about returned scaffolding only, alibabacloud.com press release empty, alizila.com 403. IMPORTANT FOR SCOPING: the Qwen team is NOT inside DAMO today. Caixin Global reports that in late 2022 Alibaba merged DAMO's language and vision AI teams into Alibaba Cloud and created Tongyi Lab, headed by Alibaba Cloud CTO Zhou Jingren. Qwen sits in Tongyi Lab, not DAMO. No day-precision date for Tongyi Lab was found."
+  },
+  {
+    "name": "Moonshot AI",
+    "founded": "2023-03",
+    "founded_precision": "month",
+    "founded_evidence": {
+      "url": "https://en.wikipedia.org/wiki/Moonshot_AI",
+      "quote": "Moonshot was founded in March 2023 by Yang Zhilin, Zhou Xinyu and Wu Yuxin who were schoolfriends at Tsinghua University.",
+      "publisher": "Wikipedia"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2023",
+        "url": "https://www.moonshot.ai/about",
+        "quote": "Moonshot AI was founded in early 2023, with a core technical team that brings together the inventors of multiple key AI technologies including Transformer-XL, RoPE, Group Normalization, ShuffleNet, MuonClip, Mooncake, and others, dedicated to finding the optimal solution for converting energy into intelligence.",
+        "what_it_represents": "first-party but vaguer than Wikipedia: 'early 2023' only, consistent with March"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "China",
+    "notes": "First-party site says only 'early 2023'; the month comes from Wikipedia, whose cited reference was not resolvable from the fetched rendering. Chinese legal entity appears in the site footer as Beijing Moonshot AI Technology Co., Ltd. Researcher's stated confidence: month ~0.8, year high."
+  },
+  {
+    "name": "Zhipu AI",
+    "founded": "2019-06-11",
+    "founded_precision": "day",
+    "founded_evidence": {
+      "url": "https://baike.baidu.com/en/item/Beijing%20Zhipu%20Huazhang%20Technology%20Co.,%20Ltd./949212",
+      "quote": "Beijing Zhipu Huazhang Technology Co., Ltd., with the stock abbreviation Z.AI and stock code 02513, is a company limited by shares primarily engaged in the science and technology promotion and application services industry...It was founded on June 11, 2019.",
+      "publisher": "Baidu Baike (English edition)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2019-06",
+        "url": "https://baike.baidu.com/en/item/Beijing%20Zhipu%20Huazhang%20Technology%20Co.,%20Ltd./949212",
+        "quote": "In June 2019, Z.AI was formally established, originating from the technological achievements transfer of the Tsinghua University Computer Science Department Knowledge Engineering Laboratory (KEG).",
+        "what_it_represents": "month-precision restatement tying the company to the Tsinghua KEG spin-out"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "China",
+    "notes": "Rebrand, not a legal rename: the company rebranded internationally as Z.ai in July 2025 alongside GLM-4.5, but the registered entity remains Beijing Zhipu Huazhang Technology Co., Ltd. Z.AI is the international brand and HKEX stock abbreviation, code 02513. Listed on HKEX 2026-01-08; that IPO prospectus would be the strongest source for the incorporation date but was not fetched. z.ai/about returned 404, so the day rests on Baidu Baike alone. Researcher's stated confidence: day ~0.75, month/year high."
+  },
+  {
+    "name": "01.AI",
+    "founded": "2023",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://www.01.ai/about.html",
+      "quote": "01.AI was founded in Beijing in May 2023 under the leadership of Dr. Kai-Fu Lee and became a unicorn within six months.",
+      "publisher": "01.AI (first-party)"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "2023-05",
+        "url": "https://www.01.ai/about.html",
+        "quote": "01.AI was founded in Beijing in May 2023 under the leadership of Dr. Kai-Fu Lee and became a unicorn within six months.",
+        "what_it_represents": "first-party statement"
+      },
+      {
+        "date": "2023-03",
+        "url": "https://en.wikipedia.org/wiki/01.AI",
+        "quote": "01.AI was founded in March 2023 by former Microsoft and Google executive and Sinovation Ventures co-founder Kai-Fu Lee.",
+        "what_it_represents": "widely repeated secondary consensus, citing Bloomberg 2023-11-05; consistent with TechNode's 2023-03-20 report of Kai-Fu Lee founding the startup"
+      }
+    ],
+    "status": "active",
+    "status_date": "2025-03",
+    "status_evidence": {
+      "url": "https://en.wikipedia.org/wiki/01.AI",
+      "quote": "In March 2025, 01.AI stopped 'pre-training' large language models to focus on selling tailored AI business solutions using DeepSeek's models."
+    },
+    "parent_org": null,
+    "country": "China",
+    "notes": "Reported at YEAR precision deliberately: the month is genuinely contested and the first-party source (May 2023) disagrees with the secondary consensus (March 2023). Plausible but UNVERIFIED reconciliation: March = public announcement / incubation inside Sinovation Ventures, May = incorporation of Beijing Lingyi Wanwu Information Technology Co., Ltd. Do not collapse without a registry record. MATERIAL FOR ANY FRONTIER-LAB COUNT: 01.AI remains an operating company but stopped pre-training its own frontier models in 2025-03 (Financial Times, 2025-03-22), so counting it as a frontier lab after that date is misleading."
+  },
+  {
+    "name": "ByteDance Seed",
+    "founded": "2023",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://github.com/ByteDance-Seed",
+      "quote": "Established in 2023, the ByteDance Seed team is dedicated to discovering new approaches to general intelligence and pushing the boundaries of AI.",
+      "publisher": "ByteDance Seed (first-party GitHub organisation profile)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2023",
+        "url": "https://en.wikipedia.org/wiki/ByteDance",
+        "quote": "ByteDance's AI team known as 'Seed' was established in 2023.",
+        "what_it_represents": "corroboration, cited there to Bloomberg"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "ByteDance",
+    "country": "China",
+    "notes": "No month precision found; both first-party and Wikipedia give only 2023. seed.bytedance.com pages are JavaScript-rendered and yielded no founding statement. Parent ByteDance founded 2012-03 per Wikipedia body text, with 2012-03-13 in the infobox only. Seed's organisational boundary has moved repeatedly: reports of a 2024 reorganisation splitting Seed and Flow, and Wu Yonghui taking over in 2025-02 with former ByteDance AI Lab teams folded in, were not independently fetched and are unverified. So 'founded 2023' names a team substantially reconstituted since."
+  },
+  {
+    "name": "Tencent",
+    "founded": "1998-11",
+    "founded_precision": "month",
+    "founded_evidence": {
+      "url": "https://en.wikipedia.org/wiki/Tencent",
+      "quote": "Tencent was founded by Pony Ma, Zhang Zhidong, Xu Chenye, Charles Chen and Zeng Liqing in November 1998",
+      "publisher": "Wikipedia"
+    },
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "1998",
+        "url": "https://www.tencent.com/en-us/about.html",
+        "quote": "Founded in 1998 with its headquarters in Shenzhen, China, Tencent's guiding principle is to use technology for good.",
+        "what_it_represents": "first-party About page, year only"
+      },
+      {
+        "date": "1998-11-07",
+        "url": "https://en.wikipedia.org/wiki/Tencent",
+        "quote": "Founded: 7 November 1998; 27 years ago (1998-11-07)",
+        "what_it_represents": "infobox value, unsourced in the fetched rendering; conflicts with the widely circulated 11 November 1998"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "China",
+    "notes": "Month precision deliberate. The day is contested: Wikipedia's infobox says 7 November, many aggregators say 11 November, and Tencent's own page gives only the year. Do not upgrade to day precision without an HKEX filing or annual report."
+  },
+  {
+    "name": "Tencent AI Lab",
+    "founded": "2016-04",
+    "founded_precision": "month",
+    "founded_evidence": {
+      "url": "https://syncedreview.com/2017/04/22/interview-with-tencent-ai-lab-four-core-research-fieldscomputer-vision-speech-recognition-natural-language-processing-and-machine-learning/",
+      "quote": "In April 2016, Tencent AI Lab was finally founded.",
+      "publisher": "Synced (SyncedReview)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2016",
+        "url": "https://www.caixinglobal.com/2026-03-21/tencent-folds-ai-lab-into-hunyuan-team-in-major-ai-overhaul-102425495.html",
+        "quote": "Tencent will disband the AI Lab established in 2016",
+        "what_it_represents": "year-only corroboration inside the 2026 disbandment story"
+      }
+    ],
+    "status": "merged",
+    "status_date": "2026-03-20",
+    "status_evidence": {
+      "url": "https://www.caixinglobal.com/2026-03-21/tencent-folds-ai-lab-into-hunyuan-team-in-major-ai-overhaul-102425495.html",
+      "quote": "Tencent will disband the AI Lab established in 2016"
+    },
+    "parent_org": "Tencent",
+    "country": "China",
+    "notes": "Separate record because its founding date differs from Tencent's. THIS UNIT NO LONGER EXISTS: Caixin Global, 2026-03-21, reports Tencent disbanding it and folding it into the Hunyuan large-model team, internal notice issued 2026-03-20, personnel moving under Chief AI Scientist Yao Shunyu. Reports that only the industry-academia collaboration centre was retained were not independently fetched. Zhang Tong became executive director in 2017-03, about a year after founding, and left in early 2019; do not confuse his arrival with the founding."
+  },
+  {
+    "name": "Huawei Noah's Ark Lab",
+    "founded": "2012",
+    "founded_precision": "year",
+    "founded_evidence": {
+      "url": "https://cse.hkust.edu.hk/ug/comp4900/S15/2015-02-04.html",
+      "quote": "The Noah's Ark Lab was founded in Hong Kong in 2012.",
+      "publisher": "HKUST Department of Computer Science and Engineering (seminar page)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2012",
+        "url": "https://baike.baidu.com/en/item/Noah's%20Ark%20Lab/928695",
+        "quote": "Noah's Ark Lab is an artificial intelligence research institution established by Huawei's 2012 Lab in 2012 at the Hong Kong Science Park.",
+        "what_it_represents": "corroboration adding the parent unit and the Hong Kong Science Park location"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": "Huawei",
+    "country": "Hong Kong SAR, China",
+    "notes": "No month precision found. No first-party Huawei statement obtained: noahlab.com.hk had no founding text and dev3.noahlab.com.hk failed TLS validation. The HKUST page is a 2015 departmental seminar page, contemporaneous and close to first-hand, but not Huawei-published. Founded in Hong Kong, later expanded to Beijing, Shenzhen, Shanghai, London, Paris and Edmonton. The parent 'Huawei 2012 Lab' name coincides with the founding year but derives from the film 2012, not the date."
+  },
+  {
+    "name": "Inspur",
+    "founded": null,
+    "founded_precision": null,
+    "founded_evidence": null,
+    "founded_contested": true,
+    "founded_alternatives": [
+      {
+        "date": "1983",
+        "url": "https://en.wikipedia.org/wiki/Inspur",
+        "quote": "Founded: 1983; 43 years ago (1983)",
+        "what_it_represents": "infobox value with no cited source; the same article is filed under the category 'Companies established in 2000', an internal contradiction"
+      },
+      {
+        "date": "1989-02-03",
+        "url": "https://baike.baidu.com/en/item/Inspur/947896",
+        "quote": "It was founded on February 3, 1989, in Jinan City, Shandong Province.",
+        "what_it_represents": "Baidu Baike's date for the entity it titles simply 'Inspur'; the same page says the predecessor was the Shandong Electronic Equipment Factory, which developed China's first Inspur microcomputer in 1983"
+      },
+      {
+        "date": "1998",
+        "url": "https://www.investing.com/equities/inspur-electronic-info-industr-company-profile",
+        "quote": "Inspur Electronic Information Industry Co., Ltd. was founded in 1998",
+        "what_it_represents": "founding of the Shenzhen-listed subsidiary 000977.SZ, now IEIT Systems, a different legal entity from Inspur Group; formerly Langchao Electronic Information Industry Co., Ltd., renamed 2006-04"
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "China",
+    "notes": "DELIBERATE NULL. 'Inspur' is not one organisation and founding is genuinely ill-defined: Inspur Group (unlisted parent, Jinan), Inspur Electronic Information Industry Co., Ltd. / IEIT Systems (000977.SZ), Inspur International and Inspur Cloud all carry the name. Four mutually inconsistent dates circulate (1945, 1983, 1989, 1998), plus 2000 for adoption of the Inspur name and 2006-04 for the listed arm's rename. The widely repeated 1945 claim could NOT be verified against any fetchable source; it appears only in commercial aggregators that were not fetched. Every first-party attempt failed to yield a date (en.inspur.com about page, inspur.com group page 404, en.ieisystem.com 404). Whoever consumes this record must first decide which Inspur entity is meant. Note also that Inspur's AI relevance is as a server and HPC vendor and developer of the Yuan LLM series, not as a research lab in the sense of the other entries."
+  },
+  {
+    "name": "Peng Cheng Laboratory",
+    "founded": "2018-03",
+    "founded_precision": "month",
+    "founded_evidence": {
+      "url": "https://baike.baidu.com/en/item/Peng%20Cheng%20Laboratory/935659",
+      "quote": "It was founded in March 2018 and primarily engages in strategic, forward-looking, and fundamental major scientific issues and key core technology research in this field.",
+      "publisher": "Baidu Baike (English edition)"
+    },
+    "founded_contested": false,
+    "founded_alternatives": [
+      {
+        "date": "2018",
+        "url": "https://merics.org/en/comment/peng-cheng-lab-pengchengshiyanshi-building-advanced-platforms-and-infrastructure-military",
+        "quote": "A 'new type of research and development institution' (xinxing yanfa jigou) set up by the Guangdong and Shenzhen governments in 2018",
+        "what_it_represents": "year-only corroboration from MERICS. The original parenthetical is in Chinese characters, transliterated to pinyin here."
+      }
+    ],
+    "status": "active",
+    "status_date": null,
+    "status_evidence": null,
+    "parent_org": null,
+    "country": "China",
+    "notes": "No day precision verifiable. March 2018 is stated by Baidu Baike and corroborated at year level by MERICS, but the sometimes-cited 2018-03-22 could NOT be confirmed and must not be adopted. First-party pages all failed: szpclab.com refused the connection, and pcl.ac.cn pages carried mission and facility text but no establishment date. PCL is a state-backed institution approved by the Central Committee of the CPC and funded by the Guangdong and Shenzhen governments, directed by Gao Wen, so there is no corporate incorporation record to appeal to; founding here means government establishment."
+  }
+]

--- a/data/serveable/api/frontier_labs/LINEAGE.json
+++ b/data/serveable/api/frontier_labs/LINEAGE.json
@@ -1,0 +1,47 @@
+{
+  "collection": "frontier_labs",
+  "schema": "frontier_labs_v1",
+  "built_by": "scripts/build/project_frontier_labs.py",
+  "inputs": {
+    "research": [
+      "data/enrichment/frontier_labs/research/batch1.json",
+      "data/enrichment/frontier_labs/research/batch3.json",
+      "data/enrichment/frontier_labs/research/batch4.json"
+    ],
+    "curation_table": "data/enrichment/frontier_labs/curation_table.json",
+    "epoch_dump": "data/raw/epoch_ai/dumps/2026-07-25_053622/raw.jsonl"
+  },
+  "inclusion_rule": {
+    "epoch_frontier_model": "Credited on at least one model flagged 'Frontier model' in the Epoch AI notable-models database with a publication date in 2000 or later. Mechanical: it is a query, not a judgement.",
+    "editorial": "Included despite the mechanical rule not selecting it. Requires inclusion_reason naming what the rule missed. Necessary because Epoch's flag is sparse -- 123 of 1,034 rows in the dump carry it -- so its absence is not evidence an organisation is not frontier.",
+    "lab_kind": "Provided so a consumer counting 'how many frontier labs exist' picks its own filter rather than inheriting ours. Counting dedicated_ai_lab gives a very different number from counting every row."
+  },
+  "counts": {
+    "total": 33,
+    "by_inclusion_basis": {
+      "editorial": 19,
+      "epoch_frontier_model": 14
+    },
+    "by_lab_kind": {
+      "corporate_division": 7,
+      "corporate_parent": 7,
+      "dedicated_ai_lab": 14,
+      "research_collective": 1,
+      "research_institute": 4
+    },
+    "by_evidence_strength": {
+      "first_party": 11,
+      "none": 3,
+      "press": 5,
+      "registry": 5,
+      "secondary": 9
+    },
+    "by_status": {
+      "active": 29,
+      "defunct": 1,
+      "merged": 3
+    },
+    "founded_null": 3,
+    "founded_contested": 7
+  }
+}

--- a/data/serveable/api/frontier_labs/LINEAGE.json
+++ b/data/serveable/api/frontier_labs/LINEAGE.json
@@ -5,6 +5,7 @@
   "inputs": {
     "research": [
       "data/enrichment/frontier_labs/research/batch1.json",
+      "data/enrichment/frontier_labs/research/batch2.json",
       "data/enrichment/frontier_labs/research/batch3.json",
       "data/enrichment/frontier_labs/research/batch4.json"
     ],
@@ -17,31 +18,32 @@
     "lab_kind": "Provided so a consumer counting 'how many frontier labs exist' picks its own filter rather than inheriting ours. Counting dedicated_ai_lab gives a very different number from counting every row."
   },
   "counts": {
-    "total": 33,
+    "total": 46,
     "by_inclusion_basis": {
-      "editorial": 19,
-      "epoch_frontier_model": 14
+      "editorial": 22,
+      "epoch_frontier_model": 24
     },
     "by_lab_kind": {
-      "corporate_division": 7,
-      "corporate_parent": 7,
-      "dedicated_ai_lab": 14,
+      "corporate_division": 11,
+      "corporate_parent": 10,
+      "dedicated_ai_lab": 19,
       "research_collective": 1,
-      "research_institute": 4
+      "research_institute": 5
     },
     "by_evidence_strength": {
-      "first_party": 11,
-      "none": 3,
-      "press": 5,
+      "first_party": 15,
+      "none": 4,
+      "press": 8,
       "registry": 5,
-      "secondary": 9
+      "secondary": 14
     },
     "by_status": {
-      "active": 29,
+      "active": 39,
       "defunct": 1,
-      "merged": 3
+      "merged": 4,
+      "renamed": 2
     },
-    "founded_null": 3,
-    "founded_contested": 7
+    "founded_null": 4,
+    "founded_contested": 16
   }
 }

--- a/data/serveable/api/frontier_labs/all_labs.json
+++ b/data/serveable/api/frontier_labs/all_labs.json
@@ -1,0 +1,1447 @@
+{
+  "schema": "frontier_labs_v1",
+  "collection": "frontier_labs",
+  "description": "Organisations that develop frontier AI systems. Facts only: no game impacts, no rarity, no salience. Inclusion is an editorial judgement and is recorded per row in inclusion_basis.",
+  "count": 33,
+  "window_start": "2000",
+  "labs": [
+    {
+      "id": "adept_ai",
+      "name": "Adept AI",
+      "aliases": [],
+      "founded": null,
+      "founded_precision": null,
+      "founded_evidence": {
+        "url": "https://techcrunch.com/2024/06/28/amazon-hires-founders-away-from-ai-startup-adept/",
+        "quote": "Adept was founded two years ago with the goal of creating an AI model that can perform actions on any software tool using natural language.",
+        "publisher": "TechCrunch (2024-06-28)"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "2022-04-26",
+          "url": "https://techcrunch.com/2022/04/26/2304039/",
+          "quote": "At a product lab called Adept that emerged from stealth today with $65 million in funding...",
+          "what_it_represents": "emergence from stealth / Series A, 2022-04-26. A launch date, NOT a founding date."
+        },
+        {
+          "date": "2022-04-27",
+          "url": "https://www.theregister.com/2022/04/27/adept_ai_google/",
+          "quote": "Adept AI, an artificial intelligence R&D lab founded by ex-Googlers who helped invent the popular transformer architecture, launched on Tuesday with the ambitious goal of teaching machines how to use 'every software tool and API in the world.'",
+          "what_it_represents": "same launch reported one day later; launched on Tuesday = 2022-04-26"
+        }
+      ],
+      "evidence_strength": "none",
+      "status": "active",
+      "status_date": "2024-06-28",
+      "status_evidence": {
+        "url": "https://techcrunch.com/2024/06/28/amazon-hires-founders-away-from-ai-startup-adept/",
+        "quote": "Adept, a startup developing AI-powered \"agents\" to complete various software-based tasks, has agreed to license its tech to Amazon, and the startup's co-founders and portions of its team have joined the e-commerce giant."
+      },
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch. Included as an agent-focused frontier developer founded by transformer co-authors, and as the collection's clearest case of a founding date that could not be sourced at all.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://techcrunch.com/2024/06/28/amazon-hires-founders-away-from-ai-startup-adept/",
+        "https://techcrunch.com/2022/04/26/2304039/",
+        "https://www.theregister.com/2022/04/27/adept_ai_google/"
+      ],
+      "notes": "FOUNDED SET TO NULL BY THE CURATOR, overriding the researcher's '2022'. That value was an inference from 'founded two years ago' in an article datelined 2024-06-28, not a quoted date. No source literally states Adept's founding date; adept.ai returns 403 so the first-party Introducing Adept post could not be read. Secondary aggregators variously assert 2022-01-05, 2022-01 and 2021; none verifiable, none adopted. Public launch 2022-04-26 is well evidenced and is recorded in founded_alternatives; use that if a date is needed, labelled as a launch. On status: reverse-acquihire, not acquisition. Amazon hired co-founder/CEO David Luan and others and licensed models and datasets, but TechCrunch says 'Adept isn't closing up shop, however', with Zach Brock becoming CEO. Headcount reportedly fell from ~100 to ~20. parent_org null because no equity acquisition is evidenced.",
+      "extra": {}
+    },
+    {
+      "id": "alibaba_damo_academy",
+      "name": "Alibaba DAMO Academy",
+      "aliases": [
+        "DAMO Academy",
+        "Alibaba DAMO"
+      ],
+      "founded": "2017-10",
+      "founded_precision": "month",
+      "founded_evidence": {
+        "url": "https://baike.baidu.com/en/item/Damo%20Academy/653561",
+        "quote": "In October 2017, the Damo Academy was established, dedicated to exploring the unknown in science and technology and conducting research in basic science and innovative technologies.",
+        "publisher": "Baidu Baike (English edition)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2017-10-11",
+          "url": "https://en.people.cn/n3/2017/1012/c90000-9278941.html",
+          "quote": "The Alibaba Group announced Wednesday it will set up a new research institute and invest over 100 billion yuan (about 15 billion U.S. dollars) over the next three years in advanced technology development.",
+          "what_it_represents": "announcement at The Computing Conference 2017 in Hangzhou, Wednesday 2017-10-11"
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "Alibaba Group",
+      "country": "China",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch under this name. Included as Alibaba's research institute, with the important caveat recorded in notes that the Qwen team moved out of DAMO into Alibaba Cloud's Tongyi Lab in late 2022 -- so this row is NOT the right home for Qwen and a consumer should not treat it as such.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://baike.baidu.com/en/item/Damo%20Academy/653561",
+        "https://en.people.cn/n3/2017/1012/c90000-9278941.html"
+      ],
+      "notes": "Founding here means public establishment of an internal Alibaba unit at the Computing Conference on 2017-10-11; there is no incorporation date. First-party attempts all failed: damo.alibaba.com/about returned scaffolding only, alibabacloud.com press release empty, alizila.com 403. IMPORTANT FOR SCOPING: the Qwen team is NOT inside DAMO today. Caixin Global reports that in late 2022 Alibaba merged DAMO's language and vision AI teams into Alibaba Cloud and created Tongyi Lab, headed by Alibaba Cloud CTO Zhou Jingren. Qwen sits in Tongyi Lab, not DAMO. No day-precision date for Tongyi Lab was found.",
+      "extra": {}
+    },
+    {
+      "id": "allen_institute_for_ai",
+      "name": "Allen Institute for AI",
+      "aliases": [
+        "AI2",
+        "Ai2"
+      ],
+      "founded": "2014",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://allenai.org/about",
+        "quote": "Philanthropist and Microsoft co-founder Paul Allen founded Ai2 in 2014 to find transformative ways to develop AI to address some of the world's biggest challenges.",
+        "publisher": "Allen Institute for AI (first-party)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2014",
+          "url": "https://en.wikipedia.org/wiki/Allen_Institute_for_AI",
+          "quote": "founded by late Microsoft co-founder and philanthropist Paul Allen in 2014",
+          "what_it_represents": "cites allenai.org/about as its source, so NOT independent corroboration"
+        }
+      ],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "research_institute",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included as a non-profit institute releasing fully open pretrained models and training data, which makes it structurally important to the field even where its models are not compute-frontier.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://allenai.org/about",
+        "https://en.wikipedia.org/wiki/Allen_Institute_for_AI"
+      ],
+      "notes": "Secondary aggregators claim 2014-01-01 and that Oren Etzioni was appointed 2013-09, but no citable page carrying that day-precision date was fetched (GeekWire returned 403), so it is deliberately NOT reported. 501(c)(3) non-profit, Seattle. Rebranded in presentation from AI2 to Ai2.",
+      "extra": {}
+    },
+    {
+      "id": "amazon",
+      "name": "Amazon",
+      "aliases": [
+        "Amazon"
+      ],
+      "founded": "1994",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://s2.q4cdn.com/299287126/files/doc_financials/annual/123197_10k.pdf",
+        "quote": "Amazon.com was incorporated in 1994 in the State of Washington and reincorporated in 1996 in Delaware.",
+        "publisher": "Amazon.com, Inc., SEC Form 10-K for FY1997, on Amazon's own investor-relations CDN"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "1994-07-05",
+          "url": "https://www.history.com/this-day-in-history/july-5/amazon-is-founded-by-jeff-bezos",
+          "quote": "On July 5, 1994, Princeton graduate and entrepreneur Jeff Bezos founds Cadabra-a twist on the magic word \"Abracadabra\"-which is initially just an online bookstore run out of his garage in Bellevue, Washington.",
+          "what_it_represents": "day of Washington State incorporation, under the original name Cadabra, Inc. Amazon was NOT named Amazon at this point. Secondary source only."
+        },
+        {
+          "date": "1995-07",
+          "url": "https://s2.q4cdn.com/299287126/files/doc_financials/annual/123197_10k.pdf",
+          "quote": "Since opening for business as \"Earth's Biggest Bookstore\" in July 1995, Amazon.com has become one of the most widely known, used and cited commerce sites on the World Wide Web.",
+          "what_it_represents": "commercial launch of the website, a year after incorporation; aboutamazon.com editorial pages tend to foreground this date instead"
+        }
+      ],
+      "evidence_strength": "registry",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 2,
+      "epoch_first_frontier_model": "2023-09-28",
+      "epoch_last_frontier_model": "2023-09-28",
+      "sources": [
+        "https://s2.q4cdn.com/299287126/files/doc_financials/annual/123197_10k.pdf",
+        "https://www.history.com/this-day-in-history/july-5/amazon-is-founded-by-jeff-bezos"
+      ],
+      "notes": "Amazon's own materials are internally inconsistent: SEC filings say incorporated 1994 in Washington, while aboutamazon.com leads with July 1995 site launch. The 1994-07-05 incorporation was under the name Cadabra, Inc. The 1997 10-K is the strongest first-party evidence found but supports only year precision.",
+      "extra": {}
+    },
+    {
+      "id": "bytedance_seed",
+      "name": "ByteDance Seed",
+      "aliases": [
+        "Seed",
+        "ByteDance"
+      ],
+      "founded": "2023",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://github.com/ByteDance-Seed",
+        "quote": "Established in 2023, the ByteDance Seed team is dedicated to discovering new approaches to general intelligence and pushing the boundaries of AI.",
+        "publisher": "ByteDance Seed (first-party GitHub organisation profile)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2023",
+          "url": "https://en.wikipedia.org/wiki/ByteDance",
+          "quote": "ByteDance's AI team known as 'Seed' was established in 2023.",
+          "what_it_represents": "corroboration, cited there to Bloomberg"
+        }
+      ],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "ByteDance",
+      "country": "China",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch under this name. Included as ByteDance's frontier model team (Doubao / Seed series). The unit has been reconstituted at least once since its 2023 establishment, which the row records.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://github.com/ByteDance-Seed",
+        "https://en.wikipedia.org/wiki/ByteDance"
+      ],
+      "notes": "No month precision found; both first-party and Wikipedia give only 2023. seed.bytedance.com pages are JavaScript-rendered and yielded no founding statement. Parent ByteDance founded 2012-03 per Wikipedia body text, with 2012-03-13 in the infobox only. Seed's organisational boundary has moved repeatedly: reports of a 2024 reorganisation splitting Seed and Flow, and Wu Yonghui taking over in 2025-02 with former ByteDance AI Lab teams folded in, were not independently fetched and are unverified. So 'founded 2023' names a team substantially reconstituted since.",
+      "extra": {}
+    },
+    {
+      "id": "cambridge_research_laboratory",
+      "name": "Cambridge Research Laboratory",
+      "aliases": [
+        "Compaq CRL"
+      ],
+      "founded": "1987",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://www.bitsavers.org/pdf/dec/tech_reports/CRL-99-6.pdf",
+        "quote": "The Cambridge Research Laboratory was founded in 1987 to advance the state of the art in both core computing and human-computer interaction, and to use the knowledge so gained to support the Company's corporate objectives.",
+        "publisher": "Compaq Computer Corporation, Cambridge Research Laboratory Technical Report CRL-99-6, 1999-09-17 (standing boilerplate in the CRL technical report series; PDF mirrored at bitsavers.org)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "1987",
+          "url": "https://www.hpcwire.com/2000/12/08/compaq-announces-cambridge-research-laboratory/",
+          "quote": "Founded in 1987, CRL has a team of more than 30 researchers, supported by advanced engineering and business development staff...",
+          "what_it_represents": "corroboration from a Compaq press announcement of 2000-12-08 for the grand opening of CRL's new facility at One Cambridge Center; confirms 1987 is Compaq's own figure, not a later reconstruction"
+        }
+      ],
+      "evidence_strength": "press",
+      "status": "defunct",
+      "status_date": null,
+      "status_evidence": {
+        "url": "https://en.wikipedia.org/wiki/HP_Labs",
+        "quote": "Cambridge, Massachusetts, United States (also known as CRL, a former DEC research lab)"
+      },
+      "parent_org": "Hewlett-Packard",
+      "country": "United States",
+      "lab_kind": "research_institute",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 1,
+      "epoch_first_frontier_model": "2001-12-08",
+      "epoch_last_frontier_model": "2001-12-08",
+      "sources": [
+        "https://www.bitsavers.org/pdf/dec/tech_reports/CRL-99-6.pdf",
+        "https://www.hpcwire.com/2000/12/08/compaq-announces-cambridge-research-laboratory/",
+        "https://en.wikipedia.org/wiki/HP_Labs"
+      ],
+      "notes": "CRITICAL: this lab was NOT founded by Compaq, despite appearing in the Epoch dump as 'Compaq CRL'. Digital Equipment Corporation founded it in 1987 as DEC's Cambridge Research Laboratory; the Computer History Museum's CRL collection covers 1987-1994 and describes it as DEC's. It became Compaq's when Compaq acquired DEC in 1998 and HP's when HP acquired Compaq. The DEC-to-Compaq closing date was NOT verified: a DEC Form 8-K of 1998-06-08 says only that the parties 'expect the transaction to close shortly after the special meeting' scheduled 1998-06-11, so the widely cited 1998-06-11 completion is unconfirmed. HP's own timeline confirms the HP-Compaq step on 2002-05-03. The CRL/DEC technical report series runs 1990-2002 and stops; Wikipedia lists Cambridge, Massachusetts among FORMER HP Labs sites. No citable closure date was found, so status_date is deliberately null. If a date is needed for 'ceased to be Compaq CRL', 2002-05-03 is the defensible one.",
+      "extra": {}
+    },
+    {
+      "id": "character_ai",
+      "name": "Character.AI",
+      "aliases": [],
+      "founded": "2021-11",
+      "founded_precision": "month",
+      "founded_evidence": {
+        "url": "https://www.forbes.com/sites/kenrickcai/2023/10/11/character-ai-chatbots-group-chat/",
+        "quote": "The pair founded Character.AI in November 2021, a year before public appetite for AI swelled when OpenAI released ChatGPT.",
+        "publisher": "Forbes (Kenrick Cai, 2023-10-11); this is the source Wikipedia cites, followed through"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2021-11",
+          "url": "https://en.wikipedia.org/wiki/Character.ai",
+          "quote": "Character.ai was established in November 2021.",
+          "what_it_represents": "prose whose citation resolves to the Forbes article above"
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": "2024-08-02",
+      "status_evidence": {
+        "url": "https://techcrunch.com/2024/08/02/character-ai-ceo-noam-shazeer-returns-to-google/",
+        "quote": "This agreement will provide increased funding for Character.AI to continue growing and to focus on building personalized AI products for users around the world"
+      },
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch. Included because it trained its own large models in-house rather than building on someone else's, and because its 2024 reverse-acquihire is a useful worked example of an event that looks like an acquisition and is not.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://www.forbes.com/sites/kenrickcai/2023/10/11/character-ai-chatbots-group-chat/",
+        "https://en.wikipedia.org/wiki/Character.ai",
+        "https://techcrunch.com/2024/08/02/character-ai-ceo-noam-shazeer-returns-to-google/"
+      ],
+      "notes": "Legal name Character Technologies, Inc.; Menlo Park, California. The 2024 Google event is a reverse-acquihire, NOT an acquisition: Google hired co-founders Noam Shazeer and Daniel De Freitas plus some staff and took a non-exclusive technology licence, while the company continued independently with Dominic Perella as interim CEO. Status left active for that reason.",
+      "extra": {}
+    },
+    {
+      "id": "cohere",
+      "name": "Cohere",
+      "aliases": [],
+      "founded": "2019",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://cohere.com/about",
+        "quote": "Cohere was founded in 2019 in Toronto with a bold vision: to do whatever it takes to scale intelligence to serve humanity.",
+        "publisher": "Cohere Inc. (first-party)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "Canada",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included as a dedicated general-purpose model developer with its own pretrained frontier-class family, whose absence from the flag reflects Epoch's coverage rather than Cohere's activity.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://cohere.com/about"
+      ],
+      "notes": "First-party but year precision only; no month or incorporation date published, no Canadian register record retrieved.",
+      "extra": {}
+    },
+    {
+      "id": "deepmind",
+      "name": "DeepMind",
+      "aliases": [
+        "DeepMind"
+      ],
+      "founded": "2010-11-15",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://find-and-update.company-information.service.gov.uk/company/07386350",
+        "quote": "FRIARS 2022 LIMITED 23 Sep 2010 - 15 Nov 2010",
+        "publisher": "Companies House, UK government (statutory register), previous-company-names entry for company 07386350"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "2010-09-23",
+          "url": "https://find-and-update.company-information.service.gov.uk/company/07386350",
+          "quote": "Incorporated on 23 September 2010",
+          "what_it_represents": "statutory incorporation of the legal entity, under the shelf-company name FRIARS 2022 LIMITED. 'A legal entity exists', not 'DeepMind exists'."
+        },
+        {
+          "date": "2010-11",
+          "url": "https://en.wikipedia.org/wiki/Google_DeepMind",
+          "quote": "The start-up was founded by Demis Hassabis, Shane Legg and Mustafa Suleyman in November 2010",
+          "what_it_represents": "the founders' public launch of the business under the DeepMind name"
+        },
+        {
+          "date": "2010",
+          "url": "https://deepmind.google/about/",
+          "quote": "DeepMind started in 2010, with an interdisciplinary approach to building general AI systems.",
+          "what_it_represents": "DeepMind's own statement, year precision only; DeepMind itself does not commit to a month"
+        }
+      ],
+      "evidence_strength": "registry",
+      "status": "merged",
+      "status_date": "2023-04-20",
+      "status_evidence": {
+        "url": "https://deepmind.google/blog/announcing-google-deepmind/",
+        "quote": "DeepMind and the Brain team from Google Research will be joining forces as a single, focused unit called Google DeepMind."
+      },
+      "parent_org": "Alphabet Inc.",
+      "country": "United Kingdom",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 10,
+      "epoch_first_frontier_model": "2015-10-01",
+      "epoch_last_frontier_model": "2021-12-08",
+      "sources": [
+        "https://find-and-update.company-information.service.gov.uk/company/07386350",
+        "https://en.wikipedia.org/wiki/Google_DeepMind",
+        "https://deepmind.google/about/",
+        "https://deepmind.google/blog/announcing-google-deepmind/"
+      ],
+      "notes": "CORRECTS A COMMON FRAMING, INCLUDING THE ONE IN THE RESEARCH BRIEF. The September/November distinction runs the opposite way to the usual telling. UK incorporation was 2010-09-23; November is when the already-incorporated shell FRIARS 2022 LIMITED was RENAMED DeepMind Technologies Limited, on 2010-11-15, which is also when the founders publicly launched. FRIARS 2022 LIMITED is a shelf-company naming pattern, so 2010-09-23 may be the shelf company's registration rather than any act by the founders. Curator has therefore taken 2010-11-15 as founded and demoted 2010-09-23 to an alternative, on the ground that it is the first date on which the thing called DeepMind existed. The legal entity 07386350 is still listed Active at Companies House despite the 2023 merger. Google's acquisition was reported 2014-01-26/27; no first-party Google announcement of the date was located, so any day-level acquisition date is press-sourced only.",
+      "extra": {}
+    },
+    {
+      "id": "deepseek",
+      "name": "DeepSeek",
+      "aliases": [],
+      "founded": "2023-07-17",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://baike.baidu.com/en/item/Hangzhou%20DeepSeek%20Artificial%20Intelligence%20Co.,%20Ltd/978595",
+        "quote": "Hangzhou DeepSeek Artificial Intelligence Co., Ltd. (commonly known as DeepSeek) was founded on July 17, 2023",
+        "publisher": "Baidu Baike (English edition)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2023-07-17",
+          "url": "https://en.wikipedia.org/wiki/DeepSeek",
+          "quote": "On 17 July 2023, that lab was spun off into an independent company.",
+          "what_it_represents": "spin-off of High-Flyer's internal AGI research lab into an independent company"
+        },
+        {
+          "date": "2023",
+          "url": "https://www.forbes.com/sites/tylerroush/2025/01/28/who-is-behind-deepseek-heres-what-to-know-about-founder-liang-wenfeng/",
+          "quote": "Liang founded DeepSeek in 2023, and the company relied on maximizing the output of processors available in China",
+          "what_it_represents": "year-only corroboration"
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "High-Flyer",
+      "country": "China",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "The most conspicuous gap in Epoch's frontier flag within the ingested dump: DeepSeek carries no flagged row, despite V3 and R1 being unambiguously frontier on release. This single row is the strongest evidence that a mechanical-only inclusion rule would have produced a wrong dataset.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://baike.baidu.com/en/item/Hangzhou%20DeepSeek%20Artificial%20Intelligence%20Co.,%20Ltd/978595",
+        "https://en.wikipedia.org/wiki/DeepSeek",
+        "https://www.forbes.com/sites/tylerroush/2025/01/28/who-is-behind-deepseek-heres-what-to-know-about-founder-liang-wenfeng/"
+      ],
+      "notes": "Owned and funded by the quantitative hedge fund High-Flyer; Liang Wenfeng is CEO of both. High-Flyer's own founding is contested because two legal entities exist: Zhejiang High-Flyer Asset Management Co., Ltd. (2015) and Ningbo High-Flyer Quant Investment Management Partnership LLP (2016), the latter now doing business as High-Flyer. The first-party page high-flyer.cn/en/about returned 404, so no first-party confirmation. The registered DeepSeek entity appears in sources as both 'Hangzhou DeepSeek Artificial Intelligence Co., Ltd.' and 'Hangzhou DeepSeek Artificial Intelligence Basic Technology Research Co., Ltd.'",
+      "extra": {}
+    },
+    {
+      "id": "eleutherai",
+      "name": "EleutherAI",
+      "aliases": [],
+      "founded": "2020-07",
+      "founded_precision": "month",
+      "founded_evidence": {
+        "url": "https://www.eleuther.ai/about",
+        "quote": "Founded in July 2020 by Connor Leahy, Sid Black, and Leo Gao, EleutherAI has grown from a Discord server for talking about GPT-3 to a leading non-profit research institute focused on large-scale artificial intelligence research.",
+        "publisher": "EleutherAI (first-party)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2023-03-02",
+          "url": "https://blog.eleuther.ai/year-two-preface/",
+          "quote": "we are thrilled to announce that we are forming a non-profit research institute, and we are excited to be able to say that over twenty of our regular contributors are now working full-time doing research.",
+          "what_it_represents": "formation of the EleutherAI Institute as a formal non-profit; post dated 2023-03-02. Says 'we are forming', so legal incorporation date is announced-adjacent, not stated."
+        }
+      ],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": null,
+      "lab_kind": "research_collective",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included because it was for a period the main source of openly available large language models, and because it is the collection's clearest example of an organisation with no incorporation date -- useful as a test of the schema's tolerance for ill-defined founding.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://www.eleuther.ai/about",
+        "https://blog.eleuther.ai/year-two-preface/"
+      ],
+      "notes": "Founding genuinely ill-defined. 2020-07 is the creation of a Discord server by volunteers: no legal entity, no incorporation, no premises, no employees. A formal non-profit was announced 2023-03-02, ~32 months later; exact incorporation date and jurisdiction not found, so country is null rather than guessed. Source page writes GPT-3 with a non-breaking hyphen (U+2011); rendered ASCII.",
+      "extra": {}
+    },
+    {
+      "id": "google",
+      "name": "Google",
+      "aliases": [
+        "Google"
+      ],
+      "founded": "1998-09",
+      "founded_precision": "month",
+      "founded_evidence": {
+        "url": "https://pages.stern.nyu.edu/adamodar/pc/blog/Google10Q3for2015.pdf",
+        "quote": "We were incorporated in California in September 1998 and re-incorporated in the State of Delaware in August",
+        "publisher": "Google Inc., SEC Form 10-Q for the quarter ended 2015-09-30 (PDF copy on the NYU Stern site of Aswath Damodaran; sec.gov returns 403 to the fetcher used)"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "1998-09-04",
+          "url": "https://www.history.co.uk/this-day-in-history/04-september/google-is-incorporated",
+          "quote": "On this day in 1998, search engine firm Google, co-founded by Larry Page and Sergey Brin, who met at Stanford University, files for incorporation in California.",
+          "what_it_represents": "day the incorporation paperwork was filed with the California Secretary of State; secondary source only"
+        },
+        {
+          "date": "1998-08",
+          "url": "https://about.google/company-info/our-story/",
+          "quote": "In August 1998, Sun co-founder Andy Bechtolsheim wrote Larry and Sergey a check for $100,000, and Google Inc. was officially born.",
+          "what_it_represents": "Google's own narrative founding moment, one month EARLIER than its own SEC-filed incorporation month. First-party but inconsistent with the filing record."
+        }
+      ],
+      "evidence_strength": "registry",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "Alphabet Inc.",
+      "country": "United States",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 40,
+      "epoch_first_frontier_model": "2007-06-22",
+      "epoch_last_frontier_model": "2023-05-10",
+      "sources": [
+        "https://pages.stern.nyu.edu/adamodar/pc/blog/Google10Q3for2015.pdf",
+        "https://www.history.co.uk/this-day-in-history/04-september/google-is-incorporated",
+        "https://about.google/company-info/our-story/"
+      ],
+      "notes": "Four candidate anchors exist and Google uses two of them: the 1996 Stanford BackRub project, 1998-08 (Bechtolsheim cheque, per about.google), 1998-09 (incorporation, per SEC filings), and a 27 September birthday with no legal meaning. The primary quote is verbatim but was truncated mid-sentence by the extraction tool at the word August, so the Delaware reincorporation year is not confirmed verbatim. Google Inc. later became Google LLC (2017) under Alphabet (formed 2015); neither date verified here.",
+      "extra": {}
+    },
+    {
+      "id": "google_brain",
+      "name": "Google Brain",
+      "aliases": [
+        "Google Brain"
+      ],
+      "founded": "2011",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://x.company/projects/brain/",
+        "quote": "When the Google Brain team began their work in 2011, AI and machine learning had been making steady but slow progress for many years.",
+        "publisher": "X, the moonshot factory (Alphabet) - first-party, since Brain began as an X project"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2012",
+          "url": "https://x.company/projects/brain/",
+          "quote": "the Brain team decided they were ready to apply their insights across a range of products at Google, so they graduated from X back to Google in late 2012 as part of Google AI.",
+          "what_it_represents": "graduation out of X into a Google organisation; the page header reads 'Graduated to Google/2012'"
+        }
+      ],
+      "evidence_strength": "first_party",
+      "status": "merged",
+      "status_date": "2023-04-20",
+      "status_evidence": {
+        "url": "https://deepmind.google/blog/announcing-google-deepmind/",
+        "quote": "DeepMind and the Brain team from Google Research will be joining forces as a single, focused unit called Google DeepMind."
+      },
+      "parent_org": "Google",
+      "country": "United States",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 6,
+      "epoch_first_frontier_model": "2016-11-05",
+      "epoch_last_frontier_model": "2020-01-28",
+      "sources": [
+        "https://x.company/projects/brain/",
+        "https://deepmind.google/blog/announcing-google-deepmind/"
+      ],
+      "notes": "No clean founding event, as suspected when the question was posed. Brain started in 2011 as a part-time research collaboration (Jeff Dean, Greg Corrado, Andrew Ng) inside Google X, much of it in 20-percent time, and became a distinct Google organisation only on graduating from X in late 2012. Even Wikipedia's 2011 infobox value cites a retrospective 2012-06-25 New York Times article. Year precision is the most the evidence supports; any month-precision date for Brain should be treated as fabricated.",
+      "extra": {}
+    },
+    {
+      "id": "google_deepmind",
+      "name": "Google DeepMind",
+      "aliases": [
+        "Google DeepMind"
+      ],
+      "founded": "2023-04-20",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://deepmind.google/blog/announcing-google-deepmind/",
+        "quote": "DeepMind and the Brain team from Google Research will be joining forces as a single, focused unit called Google DeepMind.",
+        "publisher": "Google DeepMind (Demis Hassabis), post dated 2023-04-20"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2023-04-20",
+          "url": "https://blog.google/technology/ai/april-ai-update/",
+          "quote": "This group, called Google DeepMind, will bring together two leading research groups in the AI field: the Brain team from Google Research, and DeepMind.",
+          "what_it_represents": "Sundar Pichai's parallel announcement on the Google company blog, same date, corroborating from the parent's side"
+        }
+      ],
+      "evidence_strength": "press",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "Alphabet Inc.",
+      "country": "United Kingdom",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 4,
+      "epoch_first_frontier_model": "2023-12-06",
+      "epoch_last_frontier_model": "2024-02-15",
+      "sources": [
+        "https://deepmind.google/blog/announcing-google-deepmind/",
+        "https://blog.google/technology/ai/april-ai-update/"
+      ],
+      "notes": "This is the public ANNOUNCEMENT of the merged unit, not a legal incorporation. Both announcements use future tense ('will be joining forces'), so the operational merge completed some time after 2023-04-20 and no completion date was found. Google DeepMind is an internal Alphabet business unit, not a separately incorporated company; the underlying UK entity DeepMind Technologies Limited (07386350) continues to exist. The country value reflects DeepMind's London base and was NOT separately cited; treat as low confidence.",
+      "extra": {}
+    },
+    {
+      "id": "google_research",
+      "name": "Google Research",
+      "aliases": [
+        "Google Research"
+      ],
+      "founded": null,
+      "founded_precision": null,
+      "founded_evidence": null,
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2000",
+          "url": "https://en.wikipedia.org/wiki/Google_Research",
+          "quote": "Founded: 2000 (2000)",
+          "what_it_represents": "infobox value, explicitly UNCITED in the article, no first-party corroboration found. Must not be treated as sourced."
+        },
+        {
+          "date": "2018-05-07",
+          "url": "https://research.google/blog/introducing-google-ai/",
+          "quote": "we're unifying our efforts under \"Google AI\", which encompasses all the state-of-the-art research happening across Google.",
+          "what_it_represents": "date the research division was rebranded Google AI; the Google Research name was later restored, with no dated first-party source for the restoration"
+        }
+      ],
+      "evidence_strength": "none",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "Google",
+      "country": "United States",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 8,
+      "epoch_first_frontier_model": "2017-07-10",
+      "epoch_last_frontier_model": "2022-04-04",
+      "sources": [
+        "https://en.wikipedia.org/wiki/Google_Research",
+        "https://research.google/blog/introducing-google-ai/"
+      ],
+      "notes": "DELIBERATE NULL. No citable founding date, first-party or otherwise. research.google, /philosophy and /blog were all checked; the closest first-party statements are 'Google itself began with a research paper, published in 1998' and 'Our ongoing research over the past 25 years', neither of which dates the organisation. Google Research is an organisational label that accreted rather than being founded on a date: renamed to Google AI in 2018-05 and back again, with the Brain team moving into and out of it.",
+      "extra": {}
+    },
+    {
+      "id": "huawei_noahs_ark_lab",
+      "name": "Huawei Noah's Ark Lab",
+      "aliases": [
+        "Noah's Ark Lab"
+      ],
+      "founded": "2012",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://cse.hkust.edu.hk/ug/comp4900/S15/2015-02-04.html",
+        "quote": "The Noah's Ark Lab was founded in Hong Kong in 2012.",
+        "publisher": "HKUST Department of Computer Science and Engineering (seminar page)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2012",
+          "url": "https://baike.baidu.com/en/item/Noah's%20Ark%20Lab/928695",
+          "quote": "Noah's Ark Lab is an artificial intelligence research institution established by Huawei's 2012 Lab in 2012 at the Hong Kong Science Park.",
+          "what_it_represents": "corroboration adding the parent unit and the Hong Kong Science Park location"
+        }
+      ],
+      "evidence_strength": "press",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "Huawei",
+      "country": "Hong Kong SAR, China",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included as Huawei's principal AI research lab and the origin of the Pangu model family.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://cse.hkust.edu.hk/ug/comp4900/S15/2015-02-04.html",
+        "https://baike.baidu.com/en/item/Noah's%20Ark%20Lab/928695"
+      ],
+      "notes": "No month precision found. No first-party Huawei statement obtained: noahlab.com.hk had no founding text and dev3.noahlab.com.hk failed TLS validation. The HKUST page is a 2015 departmental seminar page, contemporaneous and close to first-hand, but not Huawei-published. Founded in Hong Kong, later expanded to Beijing, Shenzhen, Shanghai, London, Paris and Edmonton. The parent 'Huawei 2012 Lab' name coincides with the founding year but derives from the film 2012, not the date.",
+      "extra": {}
+    },
+    {
+      "id": "hugging_face",
+      "name": "Hugging Face",
+      "aliases": [],
+      "founded": "2016",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://en.wikipedia.org/wiki/Hugging_Face",
+        "quote": "The company was founded in 2016 by French entrepreneurs Clement Delangue, Julien Chaumond, and Thomas Wolf in New York City",
+        "publisher": "Wikipedia"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2016",
+          "url": "https://www.forbes.com/companies/hugging-face/",
+          "quote": "Founded 2016",
+          "what_it_represents": "Forbes company-profile data field, independent of Wikipedia"
+        },
+        {
+          "date": "2017-03-09",
+          "url": "https://techcrunch.com/2017/03/09/hugging-face-wants-to-become-your-artificial-bff/",
+          "quote": "have raised $1.2 million from Betaworks, SV Angel and NBA star Kevin Durant and others",
+          "what_it_represents": "Wikipedia's cited source for the founding claim. On fetching, it does NOT state a founding date; it only references a 2016-09 private beta, which upper-bounds founding at 2016."
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch, and arguably infrastructure rather than a frontier lab. Included as a borderline case, deliberately, so that the boundary of the inclusion rule is visible in the data rather than hidden in a decision nobody recorded. A consumer disagreeing should filter it out; that is what lab_kind and inclusion_basis are for.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://en.wikipedia.org/wiki/Hugging_Face",
+        "https://www.forbes.com/companies/hugging-face/",
+        "https://techcrunch.com/2017/03/09/hugging-face-wants-to-become-your-artificial-bff/"
+      ],
+      "notes": "Weakest citation chain among the independent companies here. No first-party page stating a founding year could be located. The 2016 figure rests on Wikipedia plus a Forbes data field, and following Wikipedia's own citation through does not confirm it. Clement is spelled with an acute accent in sources; rendered ASCII. Founded in New York City as a teen chatbot app; pivoted to ML infrastructure around 2018.",
+      "extra": {}
+    },
+    {
+      "id": "ibm",
+      "name": "IBM",
+      "aliases": [
+        "IBM"
+      ],
+      "founded": "1911-06-16",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://www.ibm.com/history/ctr-and-ibm",
+        "quote": "June 16, 1911, when C-T-R was officially incorporated as a holding company to control the three separate firms.",
+        "publisher": "IBM (official IBM History site), fetched via the pure.md text proxy because ibm.com returns 403 to the fetcher used"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "1924",
+          "url": "https://www.ibm.com/history/ctr-and-ibm",
+          "quote": "Watson renamed C-T-R with the more expansive moniker of International Business Machines in 1924.",
+          "what_it_represents": "date the company took the IBM name. Anyone dating 'IBM' rather than 'the company that became IBM' gets 1924."
+        }
+      ],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Epoch flags IBM on frontier models only BEFORE 2000, so the 2000+ window rule does not select it. Included because the collection's window is a scoping choice, not a claim that IBM stopped being a research organisation, and because a timeline running to the present benefits from an entity whose frontier work predates the window.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://www.ibm.com/history/ctr-and-ibm"
+      ],
+      "notes": "The 1911 entity was the Computing-Tabulating-Recording Company, formed by Charles Flint as a holding company merging the International Time Recording Company, the Computing Scale Company and the Tabulating Machine Company. So IBM's founding is itself a merger of three older firms, each with an earlier founding date; Hollerith's Tabulating Machine Company is the oldest. IBM dates itself to 1911-06-16 and adopted the IBM name in 1924.",
+      "extra": {}
+    },
+    {
+      "id": "inspur",
+      "name": "Inspur",
+      "aliases": [
+        "Inspur"
+      ],
+      "founded": null,
+      "founded_precision": null,
+      "founded_evidence": null,
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "1983",
+          "url": "https://en.wikipedia.org/wiki/Inspur",
+          "quote": "Founded: 1983; 43 years ago (1983)",
+          "what_it_represents": "infobox value with no cited source; the same article is filed under the category 'Companies established in 2000', an internal contradiction"
+        },
+        {
+          "date": "1989-02-03",
+          "url": "https://baike.baidu.com/en/item/Inspur/947896",
+          "quote": "It was founded on February 3, 1989, in Jinan City, Shandong Province.",
+          "what_it_represents": "Baidu Baike's date for the entity it titles simply 'Inspur'; the same page says the predecessor was the Shandong Electronic Equipment Factory, which developed China's first Inspur microcomputer in 1983"
+        },
+        {
+          "date": "1998",
+          "url": "https://www.investing.com/equities/inspur-electronic-info-industr-company-profile",
+          "quote": "Inspur Electronic Information Industry Co., Ltd. was founded in 1998",
+          "what_it_represents": "founding of the Shenzhen-listed subsidiary 000977.SZ, now IEIT Systems, a different legal entity from Inspur Group; formerly Langchao Electronic Information Industry Co., Ltd., renamed 2006-04"
+        }
+      ],
+      "evidence_strength": "none",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "China",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 2,
+      "epoch_first_frontier_model": "2021-10-12",
+      "epoch_last_frontier_model": "2021-10-12",
+      "sources": [
+        "https://en.wikipedia.org/wiki/Inspur",
+        "https://baike.baidu.com/en/item/Inspur/947896",
+        "https://www.investing.com/equities/inspur-electronic-info-industr-company-profile"
+      ],
+      "notes": "DELIBERATE NULL. 'Inspur' is not one organisation and founding is genuinely ill-defined: Inspur Group (unlisted parent, Jinan), Inspur Electronic Information Industry Co., Ltd. / IEIT Systems (000977.SZ), Inspur International and Inspur Cloud all carry the name. Four mutually inconsistent dates circulate (1945, 1983, 1989, 1998), plus 2000 for adoption of the Inspur name and 2006-04 for the listed arm's rename. The widely repeated 1945 claim could NOT be verified against any fetchable source; it appears only in commercial aggregators that were not fetched. Every first-party attempt failed to yield a date (en.inspur.com about page, inspur.com group page 404, en.ieisystem.com 404). Whoever consumes this record must first decide which Inspur entity is meant. Note also that Inspur's AI relevance is as a server and HPC vendor and developer of the Yuan LLM series, not as a research lab in the sense of the other entries.",
+      "extra": {}
+    },
+    {
+      "id": "microsoft",
+      "name": "Microsoft",
+      "aliases": [
+        "Microsoft"
+      ],
+      "founded": "1975-04-04",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://paulallen.com/Futurist/Microsoft.aspx",
+        "quote": "They started Microsoft together, on April 4, 1975 in Albuquerque, New Mexico.",
+        "publisher": "paulallen.com, official site of Microsoft co-founder Paul Allen"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "1975",
+          "url": "https://news.microsoft.com/facts-about-microsoft/",
+          "quote": "1975 - Microsoft founded",
+          "what_it_represents": "Microsoft's own corporate facts page, year precision only; Microsoft itself does not publish the day here"
+        },
+        {
+          "date": "1981-06-25",
+          "url": "https://news.microsoft.com/facts-about-microsoft/",
+          "quote": "June 25, 1981 - Microsoft incorporates",
+          "what_it_represents": "legal incorporation, six years after the partnership was founded. Anyone conflating founded with incorporated gets 1981."
+        }
+      ],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 4,
+      "epoch_first_frontier_model": "2014-06-18",
+      "epoch_last_frontier_model": "2021-10-11",
+      "sources": [
+        "https://paulallen.com/Futurist/Microsoft.aspx",
+        "https://news.microsoft.com/facts-about-microsoft/"
+      ],
+      "notes": "Began as a Gates/Allen partnership in Albuquerque and did not incorporate until 1981-06-25, so founded and incorporated differ by six years, unlike most rows here. The 1975-04-04 date is co-founder-attested rather than a filing record; Allen's site and Microsoft's facts page agree on the year but only Allen's site gives the day.",
+      "extra": {}
+    },
+    {
+      "id": "microsoft_research",
+      "name": "Microsoft Research",
+      "aliases": [
+        "Microsoft Research"
+      ],
+      "founded": "1991",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://www.microsoft.com/en-us/research/about-microsoft-research/",
+        "quote": "since its founding in 1991, Microsoft Research has been committed to an academic research approach",
+        "publisher": "Microsoft Research (first-party About page)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "Microsoft",
+      "country": "United States",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 2,
+      "epoch_first_frontier_model": "2015-02-06",
+      "epoch_last_frontier_model": "2015-02-06",
+      "sources": [
+        "https://www.microsoft.com/en-us/research/about-microsoft-research/"
+      ],
+      "notes": "Year precision only; the first-party page gives no month or day. Microsoft Research has been reorganised several times, including being folded into a combined AI and Research group, but no dated first-party source for any reorganisation was located, so no status change is asserted.",
+      "extra": {}
+    },
+    {
+      "id": "mistral_ai",
+      "name": "Mistral AI",
+      "aliases": [],
+      "founded": "2023-04-28",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://recherche-entreprises.api.gouv.fr/search?q=mistral%20ai",
+        "quote": "\"date_creation\": \"2023-04-28\"",
+        "publisher": "Annuaire des Entreprises / recherche-entreprises API, DINUM, French government; SIREN 952418325, nom_complet MISTRAL AI"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2023-04",
+          "url": "https://en.wikipedia.org/wiki/Mistral_AI",
+          "quote": "Mistral AI was established in April 2023 by three French AI researchers",
+          "what_it_represents": "month-precision founding in prose; consistent with the registry date"
+        },
+        {
+          "date": "2023-09-27",
+          "url": "https://mistral.ai/news/about-mistral-ai/",
+          "quote": "Bringing open AI models to the frontier",
+          "what_it_represents": "first-party public launch; earliest post on Mistral's news page, dated 2023-09-27. Company existed ~5 months before this."
+        }
+      ],
+      "evidence_strength": "registry",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "France",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "No Mistral model carries Epoch's frontier flag in the ingested dump, but Mistral trains and releases general-purpose models at or near the open-weight frontier and is routinely named as a frontier developer in European AI governance discussion. A clear case of the flag's sparsity rather than of Mistral not qualifying.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://recherche-entreprises.api.gouv.fr/search?q=mistral%20ai",
+        "https://en.wikipedia.org/wiki/Mistral_AI",
+        "https://mistral.ai/news/about-mistral-ai/"
+      ],
+      "notes": "Strongest evidence in this batch: a government company register, not journalism. SIREN 952418325, legal form SAS, registered office Paris. A separate shell MISTRAL AI RESERVED (SIREN 992519694) exists and must not be confused with the operating company. A decoy SIREN 952481660 appears in some secondary write-ups and is wrong. Mistral's own site carries no founding-date statement.",
+      "extra": {}
+    },
+    {
+      "id": "mitsubishi_electric_research_laboratories",
+      "name": "Mitsubishi Electric Research Laboratories",
+      "aliases": [
+        "Mitsubishi Electric Research Labs",
+        "MERL",
+        "Mitsubishi Electric Information Technology Center America",
+        "ITA"
+      ],
+      "founded": "1991",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://www.merl.com/company/history",
+        "quote": "In 1991, Mitsubishi Electric's Corporate Research and Development organization (CR&D) opened MERL in Cambridge, Mass., under the leadership of Dr. Tohei Nitta and Dr. Laszlo (Les) Belady.",
+        "publisher": "Mitsubishi Electric Research Laboratories (official company history page)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "1996",
+          "url": "https://www.merl.com/company/history",
+          "quote": "In 1995, CR&D decided to combine HRI and ATL together into a new organization called Mitsubishi Electric Information Technology Center America (ITA). The next year, MERL was merged into ITA as well.",
+          "what_it_represents": "MERL absorbed into ITA in 1996, so the MERL name did not exist as a standalone organisation between 1996 and 2000"
+        },
+        {
+          "date": "2000",
+          "url": "https://www.merl.com/company/history",
+          "quote": "In 2000, the staff in Waltham moved to Cambridge, and ITA returned to the name MERL.",
+          "what_it_represents": "restoration of the MERL name after the ITA period; a refounding of the brand, though MERL claims organisational continuity from 1991"
+        }
+      ],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "Mitsubishi Electric Corporation",
+      "country": "United States",
+      "lab_kind": "research_institute",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 1,
+      "epoch_first_frontier_model": "2001-12-08",
+      "epoch_last_frontier_model": "2001-12-08",
+      "sources": [
+        "https://www.merl.com/company/history"
+      ],
+      "notes": "A US-based Cambridge, Massachusetts subsidiary lab of a Japanese parent, so country is the lab's location, not the parent's. The MERL name has a four-year gap (1996-2000) when the organisation was called ITA, which matters when matching on organisation name across a time series. Laszlo Belady's name carries an accent on the source page; transliterated to ASCII.",
+      "extra": {}
+    },
+    {
+      "id": "moonshot_ai",
+      "name": "Moonshot AI",
+      "aliases": [
+        "Kimi"
+      ],
+      "founded": "2023-03",
+      "founded_precision": "month",
+      "founded_evidence": {
+        "url": "https://en.wikipedia.org/wiki/Moonshot_AI",
+        "quote": "Moonshot was founded in March 2023 by Yang Zhilin, Zhou Xinyu and Wu Yuxin who were schoolfriends at Tsinghua University.",
+        "publisher": "Wikipedia"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2023",
+          "url": "https://www.moonshot.ai/about",
+          "quote": "Moonshot AI was founded in early 2023, with a core technical team that brings together the inventors of multiple key AI technologies including Transformer-XL, RoPE, Group Normalization, ShuffleNet, MuonClip, Mooncake, and others, dedicated to finding the optimal solution for converting energy into intelligence.",
+          "what_it_represents": "first-party but vaguer than Wikipedia: 'early 2023' only, consistent with March"
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "China",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included as a dedicated Chinese frontier-model developer (Kimi series) widely tracked as frontier-adjacent.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://en.wikipedia.org/wiki/Moonshot_AI",
+        "https://www.moonshot.ai/about"
+      ],
+      "notes": "First-party site says only 'early 2023'; the month comes from Wikipedia, whose cited reference was not resolvable from the fetched rendering. Chinese legal entity appears in the site footer as Beijing Moonshot AI Technology Co., Ltd. Researcher's stated confidence: month ~0.8, year high.",
+      "extra": {}
+    },
+    {
+      "id": "nvidia",
+      "name": "NVIDIA",
+      "aliases": [
+        "NVIDIA"
+      ],
+      "founded": "1993-04-05",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://www.nvidia.com/en-us/about-nvidia/corporate-timeline/",
+        "quote": "Founded on April 5, 1993, by Jensen Huang, Chris Malachowsky, and Curtis Priem, with a vision to bring 3D graphics to the gaming and multimedia markets.",
+        "publisher": "NVIDIA Corporation (official corporate timeline)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 8,
+      "epoch_first_frontier_model": "2019-09-17",
+      "epoch_last_frontier_model": "2024-06-14",
+      "sources": [
+        "https://www.nvidia.com/en-us/about-nvidia/corporate-timeline/"
+      ],
+      "notes": "First-party, day precision, no conflicting dates encountered. The quoted text is a timeline entry rather than a full grammatical sentence, reproduced verbatim.",
+      "extra": {}
+    },
+    {
+      "id": "peng_cheng_laboratory",
+      "name": "Peng Cheng Laboratory",
+      "aliases": [
+        "Peng Cheng Laboratory"
+      ],
+      "founded": "2018-03",
+      "founded_precision": "month",
+      "founded_evidence": {
+        "url": "https://baike.baidu.com/en/item/Peng%20Cheng%20Laboratory/935659",
+        "quote": "It was founded in March 2018 and primarily engages in strategic, forward-looking, and fundamental major scientific issues and key core technology research in this field.",
+        "publisher": "Baidu Baike (English edition)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2018",
+          "url": "https://merics.org/en/comment/peng-cheng-lab-pengchengshiyanshi-building-advanced-platforms-and-infrastructure-military",
+          "quote": "A 'new type of research and development institution' (xinxing yanfa jigou) set up by the Guangdong and Shenzhen governments in 2018",
+          "what_it_represents": "year-only corroboration from MERICS. The original parenthetical is in Chinese characters, transliterated to pinyin here."
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "China",
+      "lab_kind": "research_institute",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 2,
+      "epoch_first_frontier_model": "2021-12-23",
+      "epoch_last_frontier_model": "2021-12-23",
+      "sources": [
+        "https://baike.baidu.com/en/item/Peng%20Cheng%20Laboratory/935659",
+        "https://merics.org/en/comment/peng-cheng-lab-pengchengshiyanshi-building-advanced-platforms-and-infrastructure-military"
+      ],
+      "notes": "No day precision verifiable. March 2018 is stated by Baidu Baike and corroborated at year level by MERICS, but the sometimes-cited 2018-03-22 could NOT be confirmed and must not be adopted. First-party pages all failed: szpclab.com refused the connection, and pcl.ac.cn pages carried mission and facility text but no establishment date. PCL is a state-backed institution approved by the Central Committee of the CPC and funded by the Guangdong and Shenzhen governments, directed by Gao Wen, so there is no corporate incorporation record to appeal to; founding here means government establishment.",
+      "extra": {}
+    },
+    {
+      "id": "reka_ai",
+      "name": "Reka AI",
+      "aliases": [],
+      "founded": "2022",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://siliconangle.com/2025/07/22/multimodal-ai-startup-reka-ai-raises-110m-1b-valuation/",
+        "quote": "Founded in 2022, Reka develops multimodal models focusing on ultra-efficient training and serving infrastructure for delivering inference at low cost.",
+        "publisher": "SiliconANGLE (trade press, 2025-07-22)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2023-06-27",
+          "url": "https://www.reka.ai/news/announcing-our-60m-funding-to-build-generative-models-and-advance-ai-research",
+          "quote": "Today, we emerge from stealth",
+          "what_it_represents": "first-party emergence from stealth, dated 2023-06-27; earliest item on Reka's news index"
+        }
+      ],
+      "evidence_strength": "press",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included as a dedicated multimodal frontier-model developer founded by former DeepMind and Google Brain researchers.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://siliconangle.com/2025/07/22/multimodal-ai-startup-reka-ai-raises-110m-1b-valuation/",
+        "https://www.reka.ai/news/announcing-our-60m-funding-to-build-generative-models-and-advance-ai-research"
+      ],
+      "notes": "No first-party founding date exists on reka.ai: no about page, and the earliest news post does not say when the company started. The 2022 figure comes only from trade-press boilerplate. TRAP AVOIDED: UK Companies House lists REKA AI LTD. (number 14242489, incorporated 2022-07-19, Altrincham, one director, SIC 58290). The date is temptingly close but registered office, size and profile do not match the Sunnyvale/San Francisco lab; that record was NOT used and must not be merged in. Reported funding also disagrees: Reka's own post says $60M, press reported $58M.",
+      "extra": {}
+    },
+    {
+      "id": "safe_superintelligence",
+      "name": "Safe Superintelligence Inc",
+      "aliases": [],
+      "founded": "2024-06-19",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://en.wikipedia.org/wiki/Safe_Superintelligence_Inc.",
+        "quote": "On June 19, 2024, Sutskever posted on X that he was starting SSI Inc, with the goal to safely develop superintelligent AI",
+        "publisher": "Wikipedia"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2024-06-19",
+          "url": "https://time.com/6990076/safe-superintelligence-inc-announced/",
+          "quote": "he's launching a new venture dubbed Safe Superintelligence Inc.",
+          "what_it_represents": "public announcement; article dateline 2024-06-19"
+        },
+        {
+          "date": "2024",
+          "url": "https://ssi.inc/",
+          "quote": "Safe Superintelligence Inc. (c) 2024 - 2026",
+          "what_it_represents": "first-party copyright range, lower-bounding existence to 2024"
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Has released no model, so it cannot appear in a model database by construction. Included because a dataset of frontier labs that omits an explicitly frontier-targeting lab founded by Ilya Sutskever would mislead; a consumer wanting only shipping labs can filter on epoch_frontier_models being null.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://en.wikipedia.org/wiki/Safe_Superintelligence_Inc.",
+        "https://time.com/6990076/safe-superintelligence-inc-announced/",
+        "https://ssi.inc/"
+      ],
+      "notes": "This is the public ANNOUNCEMENT date, not a verified incorporation date. No Delaware or other registry record retrieved; actual incorporation may predate it by weeks or months. Offices in Palo Alto and Tel Aviv, so country is arguably dual. Reuters, AP, The Verge and NYT cited by Wikipedia for the same date were not fetchable.",
+      "extra": {}
+    },
+    {
+      "id": "stability_ai",
+      "name": "Stability AI",
+      "aliases": [],
+      "founded": "2019-11-04",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://find-and-update.company-information.service.gov.uk/company/12295325",
+        "quote": "Incorporated on 4 November 2019",
+        "publisher": "Companies House, GOV.UK; STABILITY AI LTD, company number 12295325"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2019",
+          "url": "https://en.wikipedia.org/wiki/Stability_AI",
+          "quote": "Stability AI was founded in 2019 by Emad Mostaque and Cyrus Hodes.",
+          "what_it_represents": "year-precision prose; agrees with the register"
+        },
+        {
+          "date": "2019-11-04",
+          "url": "https://find-and-update.company-information.service.gov.uk/company/12295325/officers",
+          "quote": "MOSTAQUE, Mohammad Emad - Appointed 4 November 2019",
+          "what_it_represents": "corroborates entity identity: directorship starts on the incorporation date; he resigned 2024-03-22"
+        }
+      ],
+      "evidence_strength": "registry",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "United Kingdom",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump, whose frontier flag tracks language-model compute far better than image generation. Included because Stable Diffusion was at the generative-image frontier on release. Note the founding date badly misrepresents this row: see notes.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://find-and-update.company-information.service.gov.uk/company/12295325",
+        "https://en.wikipedia.org/wiki/Stability_AI",
+        "https://find-and-update.company-information.service.gov.uk/company/12295325/officers"
+      ],
+      "notes": "The 2019 incorporation is real but misleading for cross-lab comparison: Stability had essentially no public AI-lab activity until 2021-2022 (Stable Diffusion released 2022-08), so a reader comparing founded dates will over-age Stability by ~3 years. Companies House lists no previous names for 12295325. Cyrus Hodes's co-founder status was later litigated. A separate US entity Stability AI Inc. exists; no registration date retrieved.",
+      "extra": {}
+    },
+    {
+      "id": "tencent",
+      "name": "Tencent",
+      "aliases": [],
+      "founded": "1998-11",
+      "founded_precision": "month",
+      "founded_evidence": {
+        "url": "https://en.wikipedia.org/wiki/Tencent",
+        "quote": "Tencent was founded by Pony Ma, Zhang Zhidong, Xu Chenye, Charles Chen and Zeng Liqing in November 1998",
+        "publisher": "Wikipedia"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "1998",
+          "url": "https://www.tencent.com/en-us/about.html",
+          "quote": "Founded in 1998 with its headquarters in Shenzhen, China, Tencent's guiding principle is to use technology for good.",
+          "what_it_represents": "first-party About page, year only"
+        },
+        {
+          "date": "1998-11-07",
+          "url": "https://en.wikipedia.org/wiki/Tencent",
+          "quote": "Founded: 7 November 1998; 27 years ago (1998-11-07)",
+          "what_it_represents": "infobox value, unsourced in the fetched rendering; conflicts with the widely circulated 11 November 1998"
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "China",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included as the parent of the Hunyuan model family and, from 2026-03, of the absorbed AI Lab. Present mainly to give Tencent AI Lab a parent to point at.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://en.wikipedia.org/wiki/Tencent",
+        "https://www.tencent.com/en-us/about.html"
+      ],
+      "notes": "Month precision deliberate. The day is contested: Wikipedia's infobox says 7 November, many aggregators say 11 November, and Tencent's own page gives only the year. Do not upgrade to day precision without an HKEX filing or annual report.",
+      "extra": {}
+    },
+    {
+      "id": "tencent_ai_lab",
+      "name": "Tencent AI Lab",
+      "aliases": [],
+      "founded": "2016-04",
+      "founded_precision": "month",
+      "founded_evidence": {
+        "url": "https://syncedreview.com/2017/04/22/interview-with-tencent-ai-lab-four-core-research-fieldscomputer-vision-speech-recognition-natural-language-processing-and-machine-learning/",
+        "quote": "In April 2016, Tencent AI Lab was finally founded.",
+        "publisher": "Synced (SyncedReview)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2016",
+          "url": "https://www.caixinglobal.com/2026-03-21/tencent-folds-ai-lab-into-hunyuan-team-in-major-ai-overhaul-102425495.html",
+          "quote": "Tencent will disband the AI Lab established in 2016",
+          "what_it_represents": "year-only corroboration inside the 2026 disbandment story"
+        }
+      ],
+      "evidence_strength": "press",
+      "status": "merged",
+      "status_date": "2026-03-20",
+      "status_evidence": {
+        "url": "https://www.caixinglobal.com/2026-03-21/tencent-folds-ai-lab-into-hunyuan-team-in-major-ai-overhaul-102425495.html",
+        "quote": "Tencent will disband the AI Lab established in 2016"
+      },
+      "parent_org": "Tencent",
+      "country": "China",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch. Included as a separate row from Tencent because it has a distinct founding date (2016-04) and a distinct end: it was disbanded into the Hunyuan team on 2026-03-20. A collection that folded it into Tencent would lose both facts.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://syncedreview.com/2017/04/22/interview-with-tencent-ai-lab-four-core-research-fieldscomputer-vision-speech-recognition-natural-language-processing-and-machine-learning/",
+        "https://www.caixinglobal.com/2026-03-21/tencent-folds-ai-lab-into-hunyuan-team-in-major-ai-overhaul-102425495.html"
+      ],
+      "notes": "Separate record because its founding date differs from Tencent's. THIS UNIT NO LONGER EXISTS: Caixin Global, 2026-03-21, reports Tencent disbanding it and folding it into the Hunyuan large-model team, internal notice issued 2026-03-20, personnel moving under Chief AI Scientist Yao Shunyu. Reports that only the industry-academia collaboration centre was retained were not independently fetched. Zhang Tong became executive director in 2017-03, about a year after founding, and left in early 2019; do not confuse his arrival with the founding.",
+      "extra": {}
+    },
+    {
+      "id": "zero_one_ai",
+      "name": "01.AI",
+      "aliases": [
+        "Yi",
+        "Beijing Lingyi Wanwu Information Technology Co., Ltd."
+      ],
+      "founded": "2023",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://www.01.ai/about.html",
+        "quote": "01.AI was founded in Beijing in May 2023 under the leadership of Dr. Kai-Fu Lee and became a unicorn within six months.",
+        "publisher": "01.AI (first-party)"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "2023-05",
+          "url": "https://www.01.ai/about.html",
+          "quote": "01.AI was founded in Beijing in May 2023 under the leadership of Dr. Kai-Fu Lee and became a unicorn within six months.",
+          "what_it_represents": "first-party statement"
+        },
+        {
+          "date": "2023-03",
+          "url": "https://en.wikipedia.org/wiki/01.AI",
+          "quote": "01.AI was founded in March 2023 by former Microsoft and Google executive and Sinovation Ventures co-founder Kai-Fu Lee.",
+          "what_it_represents": "widely repeated secondary consensus, citing Bloomberg 2023-11-05; consistent with TechNode's 2023-03-20 report of Kai-Fu Lee founding the startup"
+        }
+      ],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": "2025-03",
+      "status_evidence": {
+        "url": "https://en.wikipedia.org/wiki/01.AI",
+        "quote": "In March 2025, 01.AI stopped 'pre-training' large language models to focus on selling tailored AI business solutions using DeepSeek's models."
+      },
+      "parent_org": null,
+      "country": "China",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch in the ingested dump. Included for the Yi model family. Note the status change recorded in the row: 01.AI stopped pre-training its own models in 2025-03, so any count of currently-active frontier labs should exclude it after that date.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://www.01.ai/about.html",
+        "https://en.wikipedia.org/wiki/01.AI"
+      ],
+      "notes": "Reported at YEAR precision deliberately: the month is genuinely contested and the first-party source (May 2023) disagrees with the secondary consensus (March 2023). Plausible but UNVERIFIED reconciliation: March = public announcement / incubation inside Sinovation Ventures, May = incorporation of Beijing Lingyi Wanwu Information Technology Co., Ltd. Do not collapse without a registry record. MATERIAL FOR ANY FRONTIER-LAB COUNT: 01.AI remains an operating company but stopped pre-training its own frontier models in 2025-03 (Financial Times, 2025-03-22), so counting it as a frontier lab after that date is misleading.",
+      "extra": {}
+    },
+    {
+      "id": "zhipu_ai",
+      "name": "Zhipu AI",
+      "aliases": [
+        "Z.ai (Zhipu AI)",
+        "Z.ai",
+        "Beijing Zhipu Huazhang Technology Co., Ltd."
+      ],
+      "founded": "2019-06-11",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://baike.baidu.com/en/item/Beijing%20Zhipu%20Huazhang%20Technology%20Co.,%20Ltd./949212",
+        "quote": "Beijing Zhipu Huazhang Technology Co., Ltd., with the stock abbreviation Z.AI and stock code 02513, is a company limited by shares primarily engaged in the science and technology promotion and application services industry...It was founded on June 11, 2019.",
+        "publisher": "Baidu Baike (English edition)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2019-06",
+          "url": "https://baike.baidu.com/en/item/Beijing%20Zhipu%20Huazhang%20Technology%20Co.,%20Ltd./949212",
+          "quote": "In June 2019, Z.AI was formally established, originating from the technological achievements transfer of the Tsinghua University Computer Science Department Knowledge Engineering Laboratory (KEG).",
+          "what_it_represents": "month-precision restatement tying the company to the Tsinghua KEG spin-out"
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "China",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 1,
+      "epoch_first_frontier_model": "2024-08-29",
+      "epoch_last_frontier_model": "2024-08-29",
+      "sources": [
+        "https://baike.baidu.com/en/item/Beijing%20Zhipu%20Huazhang%20Technology%20Co.,%20Ltd./949212"
+      ],
+      "notes": "Rebrand, not a legal rename: the company rebranded internationally as Z.ai in July 2025 alongside GLM-4.5, but the registered entity remains Beijing Zhipu Huazhang Technology Co., Ltd. Z.AI is the international brand and HKEX stock abbreviation, code 02513. Listed on HKEX 2026-01-08; that IPO prospectus would be the strongest source for the incorporation date but was not fetched. z.ai/about returned 404, so the day rests on Baidu Baike alone. Researcher's stated confidence: day ~0.75, month/year high.",
+      "extra": {}
+    }
+  ]
+}

--- a/data/serveable/api/frontier_labs/all_labs.json
+++ b/data/serveable/api/frontier_labs/all_labs.json
@@ -2,7 +2,7 @@
   "schema": "frontier_labs_v1",
   "collection": "frontier_labs",
   "description": "Organisations that develop frontier AI systems. Facts only: no game impacts, no rarity, no salience. Inclusion is an editorial judgement and is recorded per row in inclusion_basis.",
-  "count": 33,
+  "count": 46,
   "window_start": "2000",
   "labs": [
     {
@@ -52,6 +52,47 @@
         "https://www.theregister.com/2022/04/27/adept_ai_google/"
       ],
       "notes": "FOUNDED SET TO NULL BY THE CURATOR, overriding the researcher's '2022'. That value was an inference from 'founded two years ago' in an article datelined 2024-06-28, not a quoted date. No source literally states Adept's founding date; adept.ai returns 403 so the first-party Introducing Adept post could not be read. Secondary aggregators variously assert 2022-01-05, 2022-01 and 2021; none verifiable, none adopted. Public launch 2022-04-26 is well evidenced and is recorded in founded_alternatives; use that if a date is needed, labelled as a launch. On status: reverse-acquihire, not acquisition. Amazon hired co-founder/CEO David Luan and others and licensed models and datasets, but TechCrunch says 'Adept isn't closing up shop, however', with Zach Brock becoming CEO. Headcount reportedly fell from ~100 to ~20. parent_org null because no equity acquisition is evidenced.",
+      "extra": {}
+    },
+    {
+      "id": "ai21_labs",
+      "name": "AI21 Labs",
+      "aliases": [
+        "AI21 Labs"
+      ],
+      "founded": "2017",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://research.contrary.com/company/ai21-labs",
+        "quote": "AI21 Labs was founded in 2017 in Israel.",
+        "publisher": "Contrary Research"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "2017-11",
+          "url": "https://en.wikipedia.org/wiki/AI21_Labs",
+          "quote": "AI21 Labs was founded in November 2017 by Yoav Shoham, Ori Goshen, and Amnon Shashua in Tel Aviv, Israel.",
+          "what_it_represents": "month precision, but WEAKLY SOURCED: the researcher followed Wikipedia's cited source through to the Globes article on AI21's 35 million USD raise, and that page contains NO founding date at all. So Wikipedia's own citation does not support its month. Curator downgraded founded to year precision for this reason."
+        }
+      ],
+      "evidence_strength": "press",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "Israel",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 2,
+      "epoch_first_frontier_model": "2021-08-11",
+      "epoch_last_frontier_model": "2021-08-11",
+      "sources": [
+        "https://research.contrary.com/company/ai21-labs",
+        "https://en.wikipedia.org/wiki/AI21_Labs"
+      ],
+      "notes": "CURATOR DOWNGRADE. The researcher reported 2017-11 at month precision; that has been reduced to 2017 at year precision, because following Wikipedia's citation through disproved the support for the month. The year is solid, corroborated independently. startupnationcentral.org returned 403 and no first-party AI21 page giving a founding date was located. This row is a worked example of why evidence_strength grades source class: a confident-sounding month with a citation that does not check out is weaker than a plain year that does.",
       "extra": {}
     },
     {
@@ -183,6 +224,134 @@
         "https://www.history.com/this-day-in-history/july-5/amazon-is-founded-by-jeff-bezos"
       ],
       "notes": "Amazon's own materials are internally inconsistent: SEC filings say incorporated 1994 in Washington, while aboutamazon.com leads with July 1995 site launch. The 1994-07-05 incorporation was under the name Cadabra, Inc. The 1997 10-K is the strongest first-party evidence found but supports only year precision.",
+      "extra": {}
+    },
+    {
+      "id": "anthropic",
+      "name": "Anthropic",
+      "aliases": [
+        "Anthropic"
+      ],
+      "founded": "2021-01",
+      "founded_precision": "month",
+      "founded_evidence": {
+        "url": "https://en.wikipedia.org/wiki/Anthropic",
+        "quote": "Anthropic was founded in January 2021",
+        "publisher": "Wikipedia"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "2021-01-26",
+          "url": "https://www.highergov.com/awardee/anthropic-pbc-782300426/",
+          "quote": "Jan. 26, 2021",
+          "what_it_represents": "Date Founded field in HigherGov's US federal awardee record for Anthropic PBC; matches Wikipedia's infobox, which cites OpenCorporates for the Delaware entity"
+        },
+        {
+          "date": "2021-02-03",
+          "url": "https://www.bizprofile.net/ca/san-francisco/anthropic-inc",
+          "quote": "Officially filed on February 3, 2021, this corporation is recognized under the document number 4688086.",
+          "what_it_represents": "California Secretary of State filing, a separate later act from the Delaware formation. Not in conflict; a different event."
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 6,
+      "epoch_first_frontier_model": "2023-07-11",
+      "epoch_last_frontier_model": "2024-06-20",
+      "sources": [
+        "https://en.wikipedia.org/wiki/Anthropic",
+        "https://www.highergov.com/awardee/anthropic-pbc-782300426/",
+        "https://www.bizprofile.net/ca/san-francisco/anthropic-inc"
+      ],
+      "notes": "anthropic.com/company was fetched and contains no founding date, so no first-party date exists to cite. The day-precision 2021-01-26 rests on HigherGov and on OpenCorporates via Wikipedia's infobox; opencorporates.com itself returned a CAPTCHA and could not be verified directly. Month precision is what the readable evidence supports.",
+      "extra": {}
+    },
+    {
+      "id": "baidu",
+      "name": "Baidu",
+      "aliases": [
+        "Baidu"
+      ],
+      "founded": "2000-01-18",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://en.wikipedia.org/wiki/Baidu",
+        "quote": "Baidu was incorporated on 18 January 2000 by Robin Li and Eric Xu.",
+        "publisher": "Wikipedia"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2000-01",
+          "url": "https://www.ebsco.com/research-starters/history/baidu-inc",
+          "quote": "Li and Xu went to China and founded Baidu in January 2000 to provide search services to portals in China.",
+          "what_it_represents": "month-precision corroboration from an independent reference publisher"
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "China",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 2,
+      "epoch_first_frontier_model": "2021-12-23",
+      "epoch_last_frontier_model": "2021-12-23",
+      "sources": [
+        "https://en.wikipedia.org/wiki/Baidu",
+        "https://www.ebsco.com/research-starters/history/baidu-inc"
+      ],
+      "notes": "The day refers to incorporation of Baidu, Inc. in the Cayman Islands. The researcher tried four times to reach Baidu's own 20-F filings on ir.baidu.com for the first-party incorporation language (three timeouts, one ECONNRESET) and sec.gov returns 403, so the day rests on Wikipedia plus an independent month-precision corroboration rather than the filing. Operations began in Beijing; the Cayman entity is the listed holding company.",
+      "extra": {}
+    },
+    {
+      "id": "baidu_research",
+      "name": "Baidu Research",
+      "aliases": [
+        "Institute of Deep Learning",
+        "Silicon Valley AI Lab"
+      ],
+      "founded": "2014-05-16",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://www.prnewswire.com/news-releases/baidu-opens-silicon-valley-lab-appoints-andrew-ng-as-head-of-baidu-research-259539471.html",
+        "quote": "Baidu, Inc. (NASDAQ: BIDU), the leading Chinese language Internet search provider, today announced the appointment of pioneering Artificial Intelligence (AI) researcher Andrew Ng as Chief Scientist of Baidu. Mr. Ng will lead Baidu Research, with labs in Beijing and Silicon Valley.",
+        "publisher": "PR Newswire, release issued by Baidu, Inc. (first-party), dateline 2014-05-16"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "2013",
+          "what_it_represents": "Baidu's Institute of Deep Learning, the predecessor lab folded into Baidu Research, is widely reported as established in 2013. UNVERIFIED: research.baidu.com serves only a maintenance notice and Wikipedia's Baidu article does not mention IDL at all. No quote given rather than attaching one that does not carry this date."
+        }
+      ],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "Baidu",
+      "country": "China",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch under this name; the flagged Baidu row attaches to the parent. Included separately because Baidu Research has a distinct, well-dated public launch (2014-05-16) and was the organisational home of Baidu's frontier work under Andrew Ng.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://www.prnewswire.com/news-releases/baidu-opens-silicon-valley-lab-appoints-andrew-ng-as-head-of-baidu-research-259539471.html"
+      ],
+      "notes": "An internal division with no incorporation record, assembled around a pre-existing lab rather than created from nothing. 2014-05-16 is the day Baidu itself named and launched Baidu Research publicly, at the grand opening of its Sunnyvale R&D centre; the release describes Baidu Research as comprising the Silicon Valley AI Lab, the Beijing Deep Learning Lab and the Beijing Big Data Lab. research.baidu.com was fetched twice and returned only a maintenance notice.",
       "extra": {}
     },
     {
@@ -793,6 +962,51 @@
       "extra": {}
     },
     {
+      "id": "inflection_ai",
+      "name": "Inflection AI",
+      "aliases": [
+        "Inflection AI"
+      ],
+      "founded": "2022",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://en.wikipedia.org/wiki/Inflection_AI",
+        "quote": "founded in 2022",
+        "publisher": "Wikipedia"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "2022-03",
+          "url": "https://www.theregister.com/2022/03/09/linkedin_hoffman_ai/",
+          "quote": "LinkedIn co-founder Reid Hoffman, DeepMind co-founder Mustafa Suleyman, and ex-DeepMind AI expert Karen Simonyan announced on Tuesday a new venture of theirs named Inflection AI.",
+          "what_it_represents": "public announcement; the sentence says 'on Tuesday' and the article dateline of 2022-03-09 makes that Tuesday 2022-03-08"
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": "2024-03-19",
+      "status_evidence": {
+        "url": "https://blogs.microsoft.com/blog/2024/03/19/mustafa-suleyman-deepmind-and-inflection-co-founder-joins-microsoft-to-lead-copilot/",
+        "quote": "Mustafa Suleyman and Karen Simonyan are joining Microsoft to form a new organization called Microsoft AI"
+      },
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 2,
+      "epoch_first_frontier_model": "2023-11-22",
+      "epoch_last_frontier_model": "2023-11-22",
+      "sources": [
+        "https://en.wikipedia.org/wiki/Inflection_AI",
+        "https://www.theregister.com/2022/03/09/linkedin_hoffman_ai/",
+        "https://blogs.microsoft.com/blog/2024/03/19/mustafa-suleyman-deepmind-and-inflection-co-founder-joins-microsoft-to-lead-copilot/"
+      ],
+      "notes": "Status is active, NOT acquired: Microsoft hired the founders and most staff and paid a licensing fee rather than buying the company; the entity continued under a new CEO with a B2B model. The widely reported 650 million USD figure and headcount are deliberately NOT recorded, because Microsoft's post does not state them and no filing was read. Karen Simonyan's name carries an accent in the sources; transliterated to ASCII.",
+      "extra": {}
+    },
+    {
       "id": "inspur",
       "name": "Inspur",
       "aliases": [
@@ -840,6 +1054,107 @@
         "https://www.investing.com/equities/inspur-electronic-info-industr-company-profile"
       ],
       "notes": "DELIBERATE NULL. 'Inspur' is not one organisation and founding is genuinely ill-defined: Inspur Group (unlisted parent, Jinan), Inspur Electronic Information Industry Co., Ltd. / IEIT Systems (000977.SZ), Inspur International and Inspur Cloud all carry the name. Four mutually inconsistent dates circulate (1945, 1983, 1989, 1998), plus 2000 for adoption of the Inspur name and 2006-04 for the listed arm's rename. The widely repeated 1945 claim could NOT be verified against any fetchable source; it appears only in commercial aggregators that were not fetched. Every first-party attempt failed to yield a date (en.inspur.com about page, inspur.com group page 404, en.ieisystem.com 404). Whoever consumes this record must first decide which Inspur entity is meant. Note also that Inspur's AI relevance is as a server and HPC vendor and developer of the Yuan LLM series, not as a research lab in the sense of the other entries.",
+      "extra": {}
+    },
+    {
+      "id": "meta_ai",
+      "name": "Meta AI",
+      "aliases": [
+        "Meta AI",
+        "FAIR",
+        "Facebook AI Research",
+        "Fundamental AI Research"
+      ],
+      "founded": "2013-12",
+      "founded_precision": "month",
+      "founded_evidence": {
+        "url": "https://www.forbes.com/sites/richardnieva/2023/11/30/meta-ai-yann-lecun-fair-10th-anniversary/",
+        "quote": "Zuckerberg and former Facebook CTO Mike Schroepfer launched FAIR in December 2013, tapping LeCun, a professor of computer science at NYU, to lead the project.",
+        "publisher": "Forbes"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2013",
+          "url": "https://ai.meta.com/blog/fair-10-year-anniversary-open-science-meta/",
+          "quote": "The launch of FAIR dates back to late 2013.",
+          "what_it_represents": "Meta's own statement, year precision only. Meta does not publish a day."
+        },
+        {
+          "date": "2013-12-09",
+          "url": "https://techcrunch.com/2013/12/09/facebook-artificial-intelligence-lab-lecun/",
+          "quote": "So today the company announced that one of the world's leading deep learning and machine learning scientists, NYU's Professor Yann LeCun, will lead its new artificial intelligence laboratory.",
+          "what_it_represents": "public announcement of the lab and of LeCun as its head; the sharpest dated public event"
+        }
+      ],
+      "evidence_strength": "press",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "Meta Platforms",
+      "country": "United States",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 4,
+      "epoch_first_frontier_model": "2024-07-23",
+      "epoch_last_frontier_model": "2025-04-05",
+      "sources": [
+        "https://www.forbes.com/sites/richardnieva/2023/11/30/meta-ai-yann-lecun-fair-10th-anniversary/",
+        "https://ai.meta.com/blog/fair-10-year-anniversary-open-science-meta/",
+        "https://techcrunch.com/2013/12/09/facebook-artificial-intelligence-lab-lecun/"
+      ],
+      "notes": "FAIR has no incorporation date; it is an internal research division, so founding means when the lab was stood up, which is inherently fuzzy. Meta's own blog says only 'late 2013'. The same TechCrunch piece notes MIT Technology Review first reported the lab in September, so internal formation predates the announcement. Later renamed from Facebook AI Research to Fundamental AI Research; no citable date for that rename was found.",
+      "extra": {}
+    },
+    {
+      "id": "meta_platforms",
+      "name": "Meta Platforms",
+      "aliases": [
+        "Facebook",
+        "Facebook AI",
+        "TheFacebook, Inc."
+      ],
+      "founded": "2004-02-04",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://en.wikipedia.org/wiki/Meta_Platforms",
+        "quote": "February 4, 2004; 22 years ago (2004-02-04) in Cambridge, Massachusetts, U.S.",
+        "publisher": "Wikipedia (infobox)"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "2004",
+          "url": "https://www.meta.com/about/company-info/",
+          "quote": "When Facebook launched in 2004, it changed the way that people connect.",
+          "what_it_represents": "Meta's own company-info page, year precision only; Meta does not publish a founding day"
+        },
+        {
+          "date": "2004-07",
+          "what_it_represents": "Delaware incorporation, separately reported as July 2004 in Meta's SEC 10-K filings. UNVERIFIED: sec.gov returns 403 to the fetcher and Meta's own annual-report PDF could not be text-extracted, so no verbatim quote exists. No quote is given rather than repeating one that does not carry this date."
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "renamed",
+      "status_date": "2021-10-28",
+      "status_evidence": {
+        "url": "https://en.wikipedia.org/wiki/Meta_Platforms",
+        "quote": "The metaverse vision and the name change from Facebook, Inc. to Meta Platforms was introduced at Facebook Connect on October 28, 2021."
+      },
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 3,
+      "epoch_first_frontier_model": "2018-05-02",
+      "epoch_last_frontier_model": "2019-11-05",
+      "sources": [
+        "https://en.wikipedia.org/wiki/Meta_Platforms",
+        "https://www.meta.com/about/company-info/"
+      ],
+      "notes": "Originally established as TheFacebook, Inc. Meta's own newsroom post on the rename is date-stamped 2021-10-28 but its prose says 'Today at Connect 2021' rather than the explicit date, so the Wikipedia sentence carrying the date inline is used instead. Three distinct dates: 2004-02-04 (TheFacebook launched, Cambridge MA), July 2004 (Delaware incorporation, unverified), 2021-10-28 (rename).",
       "extra": {}
     },
     {
@@ -1059,6 +1374,122 @@
       "extra": {}
     },
     {
+      "id": "naver",
+      "name": "NAVER",
+      "aliases": [
+        "NAVER",
+        "Naver Corporation",
+        "Naver Comm"
+      ],
+      "founded": "1999-06",
+      "founded_precision": "month",
+      "founded_evidence": {
+        "url": "https://www.navercorp.com/en/company/history",
+        "quote": "1999 (June): NAVER.com incorporated and launched Search Portal 'NAVER'",
+        "publisher": "NAVER Corporation (first-party history timeline)"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "1999-06-02",
+          "url": "https://en.wikipedia.org/wiki/Naver_Corporation",
+          "quote": "June 2, 1999; 27 years ago (1999-06-02)",
+          "what_it_represents": "day-precision incorporation from the infobox; the article body says only 'in 1999' and provides no fetchable reference for the day, so the day is unverified"
+        }
+      ],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": null,
+      "country": "South Korea",
+      "lab_kind": "corporate_parent",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 2,
+      "epoch_first_frontier_model": "2021-09-10",
+      "epoch_last_frontier_model": "2021-09-10",
+      "sources": [
+        "https://www.navercorp.com/en/company/history",
+        "https://en.wikipedia.org/wiki/Naver_Corporation"
+      ],
+      "notes": "Month precision is first-party-solid from NAVER's own history timeline. The company originated as an in-house venture inside Samsung SDS before spinning out; no citable date for that internal origin was found. Original entity name was Naver Comm.",
+      "extra": {}
+    },
+    {
+      "id": "naver_ai_lab",
+      "name": "NAVER AI Lab",
+      "aliases": [
+        "Clova AI Research"
+      ],
+      "founded": null,
+      "founded_precision": null,
+      "founded_evidence": null,
+      "founded_contested": false,
+      "founded_alternatives": [],
+      "evidence_strength": "none",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "NAVER Cloud",
+      "country": "South Korea",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch. Included as NAVER's dedicated AI research lab, and retained despite having no sourceable founding date at all -- a null row with a documented search is more useful to a consumer than a silent absence, because it distinguishes 'we looked and could not find' from 'we did not consider this'.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://naver-career.github.io/en/teams/naver-ai-lab/"
+      ],
+      "notes": "NULL BY DESIGN. NAVER's own careers page for the lab states its mission and research fields but gives no founding date of any kind. Searches surfaced only adjacent, differently-scoped facts -- CLOVA platform introduced 2017-03, HyperCLOVA launched 2021-05, CLOVA integrated into NAVER Cloud in 2023 -- and no source stating when NAVER AI Lab itself was established, nor any documenting a rename from Clova AI Research. Reporting a date here would be reconstruction.",
+      "extra": {}
+    },
+    {
+      "id": "naver_cloud",
+      "name": "NAVER Cloud",
+      "aliases": [
+        "NAVER Business Platform",
+        "NBP"
+      ],
+      "founded": "2009-05-01",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://www.navercloudcorp.com/en/info/",
+        "quote": "Date of Establishment: May 1, 2009",
+        "publisher": "NAVER Cloud Corporation (first-party)"
+      },
+      "founded_contested": false,
+      "founded_alternatives": [
+        {
+          "date": "2020",
+          "url": "https://www.navercloudcorp.com/en/info/",
+          "quote": "Changed the company name to NAVER Cloud",
+          "what_it_represents": "rename from NAVER Business Platform; the year comes from the timeline's structure rather than from prose containing it"
+        }
+      ],
+      "evidence_strength": "first_party",
+      "status": "renamed",
+      "status_date": "2020",
+      "status_evidence": {
+        "url": "https://www.navercloudcorp.com/en/info/",
+        "quote": "Changed the company name to NAVER Cloud"
+      },
+      "parent_org": "NAVER",
+      "country": "South Korea",
+      "lab_kind": "corporate_division",
+      "inclusion_basis": "editorial",
+      "inclusion_reason": "Not flagged by Epoch under this name. Included because HyperCLOVA X and NAVER's model work sit under this entity rather than under NAVER Corporation, so a consumer following parent_org from NAVER AI Lab needs it to exist.",
+      "epoch_frontier_models": null,
+      "epoch_first_frontier_model": null,
+      "epoch_last_frontier_model": null,
+      "sources": [
+        "https://www.navercloudcorp.com/en/info/"
+      ],
+      "notes": "Founded as NAVER Business Platform on 2009-05-01 per the company's own info page; renamed NAVER Cloud in 2020. HyperCLOVA X and NAVER's AI product work sit under this entity. The rename year is weaker than the establishment date because it comes from page structure rather than prose.",
+      "extra": {}
+    },
+    {
       "id": "nvidia",
       "name": "NVIDIA",
       "aliases": [
@@ -1089,6 +1520,69 @@
         "https://www.nvidia.com/en-us/about-nvidia/corporate-timeline/"
       ],
       "notes": "First-party, day precision, no conflicting dates encountered. The quoted text is a timeline entry rather than a full grammatical sentence, reproduced verbatim.",
+      "extra": {}
+    },
+    {
+      "id": "openai",
+      "name": "OpenAI",
+      "aliases": [
+        "OpenAI"
+      ],
+      "founded": "2015-12",
+      "founded_precision": "month",
+      "founded_evidence": {
+        "url": "https://en.wikipedia.org/wiki/OpenAI",
+        "quote": "In December 2015, OpenAI was founded as the nonprofit organization OpenAI, Inc.",
+        "publisher": "Wikipedia"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "2015-12-11",
+          "url": "https://techcrunch.com/2015/12/11/non-profit-openai-launches-with-backing-from-elon-musk-and-sam-altman/",
+          "quote": "Today, OpenAI, a nonprofit artificial intelligence research company was announced to the world.",
+          "what_it_represents": "public announcement; the sentence says 'Today' and the day comes from the article dateline of 2015-12-11"
+        },
+        {
+          "date": "2015-12-08",
+          "what_it_represents": "Delaware incorporation of OpenAI, Inc. per Wikipedia's infobox, which cites OpenCorporates. UNVERIFIED: opencorporates.com returned a CAPTCHA, sec.gov returned 403, and the musk-v-altman complaint PDFs could not be text-extracted. No quote is given because no page carrying this date was successfully read."
+        },
+        {
+          "date": "2015",
+          "url": "https://news.delaware.gov/2025/10/28/ag-jennings-completes-review-of-openai-recapitalization/",
+          "quote": "OpenAI, Inc. was incorporated as a Delaware nonprofit corporation in 2015",
+          "what_it_represents": "the Delaware Attorney General's own characterisation of the original incorporation, year precision. The strongest official confirmation obtained."
+        },
+        {
+          "date": "2019-03-11",
+          "url": "https://medium.com/syncedreview/openai-establishes-for-profit-company-9d595cc5f3c9",
+          "quote": "OpenAI today announced the creation of a new for-profit company",
+          "what_it_represents": "creation of the capped-profit OpenAI LP under the nonprofit"
+        }
+      ],
+      "evidence_strength": "secondary",
+      "status": "active",
+      "status_date": "2025-10-28",
+      "status_evidence": {
+        "url": "https://www.delawareinc.com/blog/openai-is-now-a-pbc/",
+        "quote": "On October 28, 2025, at 8:07 a.m. the Delaware Division of Corporation approved a 30-page Certificate of Incorporation (COI) for OPENAI GROUP PBC"
+      },
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 28,
+      "epoch_first_frontier_model": "2017-08-11",
+      "epoch_last_frontier_model": "2025-03-27",
+      "sources": [
+        "https://en.wikipedia.org/wiki/OpenAI",
+        "https://techcrunch.com/2015/12/11/non-profit-openai-launches-with-backing-from-elon-musk-and-sam-altman/",
+        "https://news.delaware.gov/2025/10/28/ag-jennings-completes-review-of-openai-recapitalization/",
+        "https://medium.com/syncedreview/openai-establishes-for-profit-company-9d595cc5f3c9",
+        "https://www.delawareinc.com/blog/openai-is-now-a-pbc/"
+      ],
+      "notes": "Founding is genuinely ill-defined: Delaware incorporation of the nonprofit (reported 2015-12-08, unverified), public announcement (2015-12-11, well sourced), then two structural events -- OpenAI LP capped-profit (2019-03-11) and recapitalisation into OpenAI Group PBC (2025-10-28). openai.com returns 403 to the fetcher and web.archive.org was blocked, so no OpenAI first-party page could be read. Status left active: the entity continues, restructured.",
       "extra": {}
     },
     {
@@ -1264,6 +1758,57 @@
       "extra": {}
     },
     {
+      "id": "technology_innovation_institute",
+      "name": "Technology Innovation Institute",
+      "aliases": [
+        "Technology Innovation Institute",
+        "TII"
+      ],
+      "founded": "2020",
+      "founded_precision": "year",
+      "founded_evidence": {
+        "url": "https://www.tii.ae/news/abu-dhabi-unveils-pioneering-global-center-advanced-technology-research",
+        "quote": "Teams of international scientists and researchers joined the institute from around the world within two months of the first board meeting in August 2020.",
+        "publisher": "Technology Innovation Institute (first-party newsroom)"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "2020-08",
+          "url": "https://www.tii.ae/news/abu-dhabi-unveils-pioneering-global-center-advanced-technology-research",
+          "quote": "Teams of international scientists and researchers joined the institute from around the world within two months of the first board meeting in August 2020.",
+          "what_it_represents": "first board meeting, the earliest concretely dated institutional event, first-party"
+        },
+        {
+          "date": "2020-11-10",
+          "url": "https://www.tii.ae/news/abu-dhabi-unveils-pioneering-global-center-advanced-technology-research",
+          "quote": "Abu Dhabi has unveiled the Technology Innovation Institute (TII), the dedicated applied research pillar of the Advanced Technology Research Council (ATRC), committed to reinforcing Abu Dhabi and the UAE's status as a global hub for innovation and advanced technologies.",
+          "what_it_represents": "public unveiling; the date is the page's dateline of 2020-11-10"
+        },
+        {
+          "date": "2020-05",
+          "what_it_represents": "Wikipedia's claimed founding month. UNVERIFIED: the researcher tried three times to reach the cited BusinessWire source (two timeouts, one ECONNRESET) and could not confirm that May 2020 appears in it. No quote given."
+        }
+      ],
+      "evidence_strength": "first_party",
+      "status": "active",
+      "status_date": null,
+      "status_evidence": null,
+      "parent_org": "Advanced Technology Research Council",
+      "country": "United Arab Emirates",
+      "lab_kind": "research_institute",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 2,
+      "epoch_first_frontier_model": "2023-09-06",
+      "epoch_last_frontier_model": "2023-09-06",
+      "sources": [
+        "https://www.tii.ae/news/abu-dhabi-unveils-pioneering-global-center-advanced-technology-research"
+      ],
+      "notes": "A government-established research institute with no incorporation record, so founding is ill-defined. tii.ae/about-us contains no founding date. Three candidates: May 2020 (unverified), August 2020 (first board meeting, first-party), 2020-11-10 (public unveiling, first-party). Year precision because the month cannot be honestly resolved from what was read. TII is the lab behind the Falcon model family.",
+      "extra": {}
+    },
+    {
       "id": "tencent",
       "name": "Tencent",
       "aliases": [],
@@ -1348,6 +1893,57 @@
         "https://www.caixinglobal.com/2026-03-21/tencent-folds-ai-lab-into-hunyuan-team-in-major-ai-overhaul-102425495.html"
       ],
       "notes": "Separate record because its founding date differs from Tencent's. THIS UNIT NO LONGER EXISTS: Caixin Global, 2026-03-21, reports Tencent disbanding it and folding it into the Hunyuan large-model team, internal notice issued 2026-03-20, personnel moving under Chief AI Scientist Yao Shunyu. Reports that only the industry-academia collaboration centre was retained were not independently fetched. Zhang Tong became executive director in 2017-03, about a year after founding, and left in early 2019; do not confuse his arrival with the founding.",
+      "extra": {}
+    },
+    {
+      "id": "xai",
+      "name": "xAI",
+      "aliases": [
+        "xAI",
+        "X.AI Corp."
+      ],
+      "founded": "2023-03-09",
+      "founded_precision": "day",
+      "founded_evidence": {
+        "url": "https://www.ktnv.com/news/elon-musk-files-nevada-business-formation-for-x-ai",
+        "quote": "The filing was from March 9, 2023.",
+        "publisher": "KTNV Las Vegas (Scripps), reporting from Nevada Secretary of State business records"
+      },
+      "founded_contested": true,
+      "founded_alternatives": [
+        {
+          "date": "2023-03-09",
+          "url": "https://en.wikipedia.org/wiki/XAI_(company)",
+          "quote": "Elon Musk founded xAI on March 9, 2023.",
+          "what_it_represents": "incorporation of X.AI Corp. in Nevada"
+        },
+        {
+          "date": "2023-07-12",
+          "url": "https://en.wikipedia.org/wiki/XAI_(company)",
+          "quote": "Musk announced xAI on July 12, 2023.",
+          "what_it_represents": "public announcement of the company and founding technical team, four months after incorporation"
+        }
+      ],
+      "evidence_strength": "press",
+      "status": "merged",
+      "status_date": "2025-03-28",
+      "status_evidence": {
+        "url": "https://en.wikipedia.org/wiki/XAI_(company)",
+        "quote": "On March 28, 2025, Musk announced that xAI acquired sister company X Corp., the developer of social media platform X."
+      },
+      "parent_org": null,
+      "country": "United States",
+      "lab_kind": "dedicated_ai_lab",
+      "inclusion_basis": "epoch_frontier_model",
+      "inclusion_reason": null,
+      "epoch_frontier_models": 6,
+      "epoch_first_frontier_model": "2024-08-13",
+      "epoch_last_frontier_model": "2025-07-09",
+      "sources": [
+        "https://www.ktnv.com/news/elon-musk-files-nevada-business-formation-for-x-ai",
+        "https://en.wikipedia.org/wiki/XAI_(company)"
+      ],
+      "notes": "x.ai returns 403 to the fetcher, so no first-party page was read. The Nevada filing date is corroborated by a local outlet that inspected the Secretary of State record; the record itself was not reached. Status merged reflects xAI acquiring X Corp. in an all-stock deal placing both under a holding company; xAI is the surviving AI operation, not the acquired party, but the corporate perimeter changed materially.",
       "extra": {}
     },
     {

--- a/scripts/build/project_frontier_labs.py
+++ b/scripts/build/project_frontier_labs.py
@@ -1,0 +1,452 @@
+"""Project the curated frontier-labs rows into the serveable zone.
+
+    python scripts/build/project_frontier_labs.py           # build
+    python scripts/build/project_frontier_labs.py --check   # assert committed
+                                                            # output matches a
+                                                            # fresh build
+
+data/serveable/ is a build output. Never hand-edit it. This repo previously
+lost that property for seven months -- MANIFEST.json said 28 events while
+all_events.json said 1,194, because two producers wrote to one zone and
+nothing compared them -- so --check exists to make the claim executable rather
+than aspirational.
+
+Inputs are split so that evidence and judgement can be reviewed separately:
+
+    data/enrichment/frontier_labs/research/*.json   what was read. Each row
+                                                    carries the URL and the
+                                                    verbatim sentence. Treat as
+                                                    an evidence record and do
+                                                    not edit to change a verdict.
+    data/enrichment/frontier_labs/curation_table.json  the judgement calls: id,
+                                                    lab_kind, inclusion_basis
+                                                    and, for editorial rows, the
+                                                    reason the mechanical rule
+                                                    missed them.
+
+Cross-reference:      the newest data/raw/epoch_ai dump, read-only
+Output:               data/serveable/api/frontier_labs/
+
+Every founding date in the input carries the URL that was read and the
+verbatim sentence containing the date. Where no citable date was found the
+date is null, which is ungated and honest; a fabricated clock is
+indistinguishable from a real one later.
+"""
+import argparse
+import glob
+import io
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+LABS_DIR = os.path.join(REPO_ROOT, "data", "enrichment", "frontier_labs")
+RESEARCH_GLOB = os.path.join(LABS_DIR, "research", "*.json")
+CURATION_TABLE = os.path.join(LABS_DIR, "curation_table.json")
+EPOCH_GLOB = os.path.join(REPO_ROOT, "data", "raw", "epoch_ai", "dumps", "*", "raw.jsonl")
+OUT_DIR = os.path.join(REPO_ROOT, "data", "serveable", "api", "frontier_labs")
+SCHEMA = os.path.join(REPO_ROOT, "config", "schemas", "frontier_labs_v1.json")
+
+# The window the collection covers. Organisations whose only Epoch-flagged
+# frontier models predate this are out of scope for inclusion_basis
+# epoch_frontier_model, though they may still enter editorially.
+WINDOW_START = "2000"
+
+SCHEMA_VERSION = "frontier_labs_v1"
+
+
+def slugify(name):
+    """Stable snake_case id.
+
+    Note the trailing-punctuation handling: an earlier slugify in this repo
+    stripped a trailing '+', which silently merged PointNet and PointNet++
+    into one id. A consumer keying by id loses a record when that happens, and
+    nothing errors. So '+' and '.' are transliterated rather than dropped.
+    """
+    s = name.lower().strip()
+    s = s.replace("+", "_plus")
+    s = s.replace("&", "_and_")
+    s = s.replace(".", "_dot_")
+    s = re.sub(r"[^a-z0-9]+", "_", s)
+    s = re.sub(r"_+", "_", s).strip("_")
+    return s
+
+
+def newest_epoch_dump():
+    paths = sorted(glob.glob(EPOCH_GLOB))
+    return paths[-1] if paths else None
+
+
+def epoch_frontier_stats():
+    """org name -> {'n', 'first', 'last'} over Epoch-flagged frontier models.
+
+    Epoch's 'Frontier model' flag is era-relative: it marks the 1958 Perceptron
+    as frontier for its time. It is also SPARSE -- 123 of 1,034 rows in the
+    dump carry it -- so its absence is not evidence an organisation is not
+    frontier. DeepSeek, Mistral and Alibaba have no flagged row at all. That
+    sparsity is exactly why the collection has a second, editorial inclusion
+    basis.
+    """
+    path = newest_epoch_dump()
+    stats = defaultdict(lambda: {"n": 0, "first": None, "last": None})
+    if not path:
+        return stats, None
+    for line in io.open(path, encoding="utf-8"):
+        line = line.strip()
+        if not line:
+            continue
+        r = json.loads(line)
+        if str(r.get("Frontier model")).strip() != "True":
+            continue
+        d = str(r.get("Publication date", "")).strip()
+        if not d or d[:4] < WINDOW_START:
+            continue
+        for org in str(r.get("Organization", "")).split(","):
+            org = org.strip()
+            if not org:
+                continue
+            a = stats[org]
+            a["n"] += 1
+            if a["first"] is None or d < a["first"]:
+                a["first"] = d
+            if a["last"] is None or d > a["last"]:
+                a["last"] = d
+    return stats, os.path.relpath(path, REPO_ROOT).replace("\\", "/")
+
+
+def derive_evidence_strength(row):
+    """Grade on source class, not on how confident the prose sounds.
+
+    A statutory register outranks a company's own about page, which outranks
+    journalism, which outranks an encyclopedia infobox whose citation does not
+    resolve. This is deliberately mechanical: 'how sure am I' is not a
+    property of the evidence.
+    """
+    if row.get("founded") is None:
+        return "none"
+    ev = row.get("founded_evidence") or {}
+    pub = (ev.get("publisher") or "").lower()
+    url = (ev.get("url") or "").lower()
+
+    registry_marks = ("companies house", "company-information.service.gov.uk",
+                      "recherche-entreprises", "annuaire des entreprises",
+                      "sec form", "form 10-k", "form 10-q", "statutory register")
+    if any(m in pub for m in registry_marks) or any(m in url for m in registry_marks):
+        return "registry"
+    if "first-party" in pub or "official" in pub:
+        return "first_party"
+    if "wikipedia" in pub or "wikipedia" in url or "baike" in url:
+        return "secondary"
+    if "forbes.com/companies" in url or "investing.com" in url:
+        return "secondary"
+    return "press"
+
+
+def load_research():
+    """Every row from every research file, with its source file recorded.
+
+    A name appearing in two research files is an error rather than something to
+    silently resolve: the two rows may disagree about the date, and picking one
+    by file order would hide the disagreement.
+    """
+    paths = sorted(glob.glob(RESEARCH_GLOB))
+    if not paths:
+        sys.stderr.write(
+            "no research files under %s\n"
+            "This collection has no upstream dump to project from; the rows are\n"
+            "hand-researched and those files are the source of record.\n"
+            % os.path.relpath(os.path.dirname(RESEARCH_GLOB), REPO_ROOT))
+        sys.exit(2)
+    rows = []
+    origin = {}
+    for p in paths:
+        rel = os.path.relpath(p, REPO_ROOT).replace("\\", "/")
+        with io.open(p, encoding="utf-8") as f:
+            batch = json.load(f)
+        for row in batch:
+            name = row["name"]
+            if name in origin:
+                raise SystemExit(
+                    "%r appears in both %s and %s. Two research rows for one "
+                    "organisation may disagree; resolve it in the research "
+                    "files rather than letting file order decide."
+                    % (name, origin[name], rel))
+            origin[name] = rel
+            row["_research_file"] = rel
+            rows.append(row)
+    return rows, sorted(set(origin.values()))
+
+
+def load_curation():
+    if not os.path.isfile(CURATION_TABLE):
+        sys.stderr.write("missing curation table: %s\n"
+                         % os.path.relpath(CURATION_TABLE, REPO_ROOT))
+        sys.exit(2)
+    with io.open(CURATION_TABLE, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def build():
+    rows_in, research_files = load_research()
+    table = load_curation()
+    curation = table["labs"]
+
+    # Both directions. A researched organisation with no curation entry would
+    # be silently dropped; a curation entry with no research would be a row
+    # asserting a judgement about something nobody looked up.
+    researched = set(r["name"] for r in rows_in)
+    curated = set(curation.keys())
+    missing_curation = sorted(researched - curated)
+    missing_research = sorted(curated - researched)
+    if missing_curation:
+        raise SystemExit(
+            "researched but not in the curation table, so they would be "
+            "silently dropped: %s" % ", ".join(missing_curation))
+    if missing_research:
+        raise SystemExit(
+            "in the curation table but never researched: %s"
+            % ", ".join(missing_research))
+
+    for row in rows_in:
+        row.update({k: v for k, v in curation[row["name"]].items()
+                    if k not in ("aliases",)})
+        row["aliases"] = curation[row["name"]].get("aliases", [])
+        row.setdefault("sources", [])
+        # Build the sources list from every URL the research actually cites.
+        urls = []
+        ev = row.get("founded_evidence") or {}
+        if ev.get("url"):
+            urls.append(ev["url"])
+        for alt in row.get("founded_alternatives", []):
+            if alt.get("url"):
+                urls.append(alt["url"])
+        sev = row.get("status_evidence") or {}
+        if sev.get("url"):
+            urls.append(sev["url"])
+        seen = set()
+        row["sources"] = [u for u in urls if not (u in seen or seen.add(u))]
+        if not row["sources"]:
+            raise SystemExit(
+                "%r cites no URL at all. Every row must record what was read, "
+                "including rows whose date is null." % row["name"])
+
+    stats, epoch_path = epoch_frontier_stats()
+
+    out = []
+    seen_ids = {}
+    for row in rows_in:
+        name = row["name"]
+        rid = row.get("id") or slugify(name)
+        if rid in seen_ids:
+            raise SystemExit(
+                "duplicate id %r from %r and %r -- ids must be unique or a "
+                "consumer keying by id silently loses a record"
+                % (rid, seen_ids[rid], name))
+        seen_ids[rid] = name
+
+        aliases = row.get("aliases", [])
+        # Sum Epoch stats across every name this organisation appears under.
+        n = 0
+        first = None
+        last = None
+        matched_any = False
+        for candidate in [name] + list(aliases):
+            if candidate in stats:
+                matched_any = True
+                a = stats[candidate]
+                n += a["n"]
+                if a["first"] and (first is None or a["first"] < first):
+                    first = a["first"]
+                if a["last"] and (last is None or a["last"] > last):
+                    last = a["last"]
+
+        rec = {
+            "id": rid,
+            "name": name,
+            "aliases": aliases,
+            "founded": row.get("founded"),
+            "founded_precision": row.get("founded_precision"),
+            "founded_evidence": row.get("founded_evidence"),
+            "founded_contested": bool(row.get("founded_contested", False)),
+            "founded_alternatives": row.get("founded_alternatives", []),
+            "evidence_strength": row.get("evidence_strength") or derive_evidence_strength(row),
+            "status": row.get("status", "unknown"),
+            "status_date": row.get("status_date"),
+            "status_evidence": row.get("status_evidence"),
+            "parent_org": row.get("parent_org"),
+            "country": row.get("country"),
+            "lab_kind": row["lab_kind"],
+            "inclusion_basis": row["inclusion_basis"],
+            "inclusion_reason": row.get("inclusion_reason"),
+            "epoch_frontier_models": n if matched_any else None,
+            "epoch_first_frontier_model": first,
+            "epoch_last_frontier_model": last,
+            "sources": row["sources"],
+            "notes": row.get("notes"),
+            "extra": row.get("extra", {}),
+        }
+
+        # A row claiming the mechanical basis must actually satisfy it.
+        if rec["inclusion_basis"] == "epoch_frontier_model" and not matched_any:
+            raise SystemExit(
+                "%r claims inclusion_basis epoch_frontier_model but matches no "
+                "organisation in the Epoch dump under its name or aliases. "
+                "Either add the alias Epoch uses, or move the row to editorial "
+                "with a reason." % name)
+
+        out.append(rec)
+
+    out.sort(key=lambda r: r["id"])
+    return out, epoch_path, research_files, table.get("_inclusion_rule_v1", {})
+
+
+def validate(records):
+    try:
+        import jsonschema
+    except ImportError:
+        return ["jsonschema not installed; schema validation skipped"]
+    with io.open(SCHEMA, encoding="utf-8") as f:
+        schema = json.load(f)
+    errs = []
+    v = jsonschema.Draft7Validator(schema)
+    for r in records:
+        for e in sorted(v.iter_errors(r), key=lambda e: e.path):
+            errs.append("%s: %s" % (r["id"], e.message))
+    return errs
+
+
+def ascii_check(records):
+    bad = []
+    for r in records:
+        blob = json.dumps(r, ensure_ascii=False)
+        for ch in blob:
+            if ord(ch) > 127:
+                bad.append("%s: non-ASCII U+%04X (%r)" % (r["id"], ord(ch), ch))
+                break
+    return bad
+
+
+def render(records, epoch_path, research_files, inclusion_rule):
+    payload = {
+        "schema": SCHEMA_VERSION,
+        "collection": "frontier_labs",
+        "description": (
+            "Organisations that develop frontier AI systems. Facts only: no "
+            "game impacts, no rarity, no salience. Inclusion is an editorial "
+            "judgement and is recorded per row in inclusion_basis."
+        ),
+        "count": len(records),
+        "window_start": WINDOW_START,
+        "labs": records,
+    }
+    lineage = {
+        "collection": "frontier_labs",
+        "schema": SCHEMA_VERSION,
+        "built_by": "scripts/build/project_frontier_labs.py",
+        "inputs": {
+            "research": research_files,
+            "curation_table": os.path.relpath(CURATION_TABLE, REPO_ROOT).replace("\\", "/"),
+            "epoch_dump": epoch_path,
+        },
+        "inclusion_rule": inclusion_rule,
+        "counts": {
+            "total": len(records),
+            "by_inclusion_basis": _count(records, "inclusion_basis"),
+            "by_lab_kind": _count(records, "lab_kind"),
+            "by_evidence_strength": _count(records, "evidence_strength"),
+            "by_status": _count(records, "status"),
+            "founded_null": sum(1 for r in records if r["founded"] is None),
+            "founded_contested": sum(1 for r in records if r["founded_contested"]),
+        },
+    }
+    return payload, lineage
+
+
+def _count(records, key):
+    c = defaultdict(int)
+    for r in records:
+        c[r[key]] += 1
+    return dict(sorted(c.items()))
+
+
+def write_json(path, obj):
+    """Write via temp + os.replace.
+
+    Never open an existing file with encoding='ascii' for writing: Python
+    truncates on open and then raises on the first non-ASCII byte, destroying
+    the file before the error surfaces. That ate two files in one session.
+    """
+    tmp = path + ".tmp"
+    with io.open(tmp, "w", encoding="utf-8", newline="\n") as f:
+        json.dump(obj, f, indent=2, ensure_ascii=True, sort_keys=False)
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--check", action="store_true",
+                    help="assert the committed output matches a fresh build; "
+                         "write nothing")
+    args = ap.parse_args()
+
+    records, epoch_path, research_files, inclusion_rule = build()
+
+    errs = validate(records)
+    bad = ascii_check(records)
+    for e in errs:
+        print("SCHEMA: " + e)
+    for b in bad:
+        print("ASCII: " + b)
+    if errs and not errs[0].startswith("jsonschema not installed"):
+        return 1
+    if bad:
+        return 1
+
+    payload, lineage = render(records, epoch_path, research_files, inclusion_rule)
+
+    feed_path = os.path.join(OUT_DIR, "all_labs.json")
+    lineage_path = os.path.join(OUT_DIR, "LINEAGE.json")
+
+    print("labs                : %d" % len(records))
+    for k, v in lineage["counts"]["by_inclusion_basis"].items():
+        print("  basis %-22s %d" % (k, v))
+    for k, v in lineage["counts"]["by_evidence_strength"].items():
+        print("  evidence %-19s %d" % (k, v))
+    print("founded null        : %d" % lineage["counts"]["founded_null"])
+    print("founded contested   : %d" % lineage["counts"]["founded_contested"])
+
+    if args.check:
+        if not os.path.isfile(feed_path):
+            print("CHECK FAILED: %s does not exist" % feed_path)
+            return 1
+        with io.open(feed_path, encoding="utf-8") as f:
+            committed = json.load(f)
+        if committed != payload:
+            print("CHECK FAILED: committed feed differs from a fresh build. "
+                  "data/serveable/ is a build output; re-run without --check.")
+            return 1
+        # LINEAGE carries no wall-clock stamp by design, so it must match too.
+        if os.path.isfile(lineage_path):
+            with io.open(lineage_path, encoding="utf-8") as f:
+                if json.load(f) != lineage:
+                    print("CHECK FAILED: committed LINEAGE differs from a "
+                          "fresh build.")
+                    return 1
+        print("CHECK OK: committed output matches a fresh build")
+        return 0
+
+    if not os.path.isdir(OUT_DIR):
+        os.makedirs(OUT_DIR)
+    write_json(feed_path, payload)
+    write_json(lineage_path, lineage)
+    print("wrote %s" % os.path.relpath(feed_path, REPO_ROOT).replace("\\", "/"))
+    print("wrote %s" % os.path.relpath(lineage_path, REPO_ROOT).replace("\\", "/"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build/project_frontier_labs.py
+++ b/scripts/build/project_frontier_labs.py
@@ -225,6 +225,10 @@ def build():
         sev = row.get("status_evidence") or {}
         if sev.get("url"):
             urls.append(sev["url"])
+        # A row whose date is null still consulted pages. sources_extra records
+        # what was checked and found wanting, which is the evidence that the
+        # null is a finding rather than an omission.
+        urls.extend(row.get("sources_extra", []))
         seen = set()
         row["sources"] = [u for u in urls if not (u in seen or seen.add(u))]
         if not row["sources"]:
@@ -317,6 +321,54 @@ def validate(records):
     return errs
 
 
+def sanity_check(records):
+    """Cross-check the curated dates against Epoch, and against themselves.
+
+    The useful test here is the cross-source one: an organisation cannot be
+    credited on a frontier model published BEFORE it existed. Founding dates
+    and Epoch publication dates come from entirely independent sources, so a
+    violation means one of them is wrong -- and neither would look wrong on its
+    own. Cross-checking two numbers that should agree is what found the
+    PointNet id collision last session; reading the code found nothing.
+
+    Comparison is on the common prefix, so a year-precision founding date is
+    only compared at year granularity. Otherwise '2015' would spuriously fail
+    against a 2015-03 model.
+    """
+    problems = []
+    for r in records:
+        f = r["founded"]
+        if f is not None:
+            year = int(f[:4])
+            if not (1900 <= year <= 2030):
+                problems.append("%s: founded year %d is outside 1900-2030"
+                                % (r["id"], year))
+
+        first = r["epoch_first_frontier_model"]
+        if f and first:
+            n = min(len(f), len(first))
+            if first[:n] < f[:n]:
+                problems.append(
+                    "%s: credited on an Epoch frontier model published %s, "
+                    "which is BEFORE its founding date %s. One of the two "
+                    "sources is wrong, or the Epoch alias matches the wrong "
+                    "organisation." % (r["id"], first, f))
+
+        sd = r["status_date"]
+        if f and sd:
+            n = min(len(f), len(sd))
+            if sd[:n] < f[:n]:
+                problems.append("%s: status_date %s precedes founded %s"
+                                % (r["id"], sd, f))
+
+        # A null date must not be dressed up with a precision or a strength
+        # that implies one exists.
+        if f is None and r["founded_precision"] is not None:
+            problems.append("%s: founded is null but founded_precision is %r"
+                            % (r["id"], r["founded_precision"]))
+    return problems
+
+
 def ascii_check(records):
     bad = []
     for r in records:
@@ -397,13 +449,16 @@ def main():
 
     errs = validate(records)
     bad = ascii_check(records)
+    sane = sanity_check(records)
     for e in errs:
         print("SCHEMA: " + e)
     for b in bad:
         print("ASCII: " + b)
+    for s in sane:
+        print("SANITY: " + s)
     if errs and not errs[0].startswith("jsonschema not installed"):
         return 1
-    if bad:
+    if bad or sane:
         return 1
 
     payload, lineage = render(records, epoch_path, research_files, inclusion_rule)


### PR DESCRIPTION
Answers #37. Unblocks pdoom1#962 and lets pdoom1-website's `scripts/calculate-game-stats.py` stop deriving `frontier_labs_count` from a hardcoded list.

**Stacked on #40** — review that first; this PR's diff is against that branch.

## The editorial call, stated rather than implied

A definition based on *current* capability would be wrong here: the collection feeds a 2000-to-present timeline, so it needs organisations that *were* frontier, not only those that are. Inclusion is a disjunction and the branch is recorded per row.

- **`epoch_frontier_model`** — mechanical. Credited on a model flagged `Frontier model` in Epoch AI's database, published 2000+. A query, not a judgement. 24 rows.
- **`editorial`** — a judgement, requiring `inclusion_reason` to name what the mechanical rule missed. 22 rows.

**The editorial branch is not a convenience.** Epoch's flag is sparse — 123 of 1,034 rows carry it — so its absence is not evidence against an organisation. The decisive case: **DeepSeek has no flagged row at all**, despite V3 and R1. A mechanical-only rule would have shipped a frontier-labs dataset with no DeepSeek in it.

Two rows are deliberately borderline rather than quietly omitted — Hugging Face (arguably infrastructure) and Safe Superintelligence (has shipped no model, so cannot appear in a model database by construction) — so the boundary of the rule is visible in the data where a disagreeing consumer can filter it.

## `frontier_labs_count` is not `len(labs)`

`lab_kind` is carried so the consumer picks what to count. Counting rows double-counts Google, which appears five times — Google, Google Research, Google Brain, DeepMind, Google DeepMind — each with its own founding date and two with distinct ends. That redundancy is deliberate; collapsing it would destroy the merger facts. Choosing the filter is the consumer's call, which is the fact/opinion firewall applied to counting.

Two rows will inflate a naive count of *currently active* frontier labs: **Tencent AI Lab** was disbanded into Hunyuan on 2026-03-20, and **01.AI** stopped pre-training in 2025-03.

## Dates carry their evidence

Every non-null `founded` has the URL that was read and the verbatim sentence containing the date. `evidence_strength` grades the **source class** — registry > first_party > press > secondary — not how confident the prose sounds, because confidence is not a property of evidence.

**Four rows are `null` on purpose**: Google Research (only an uncited infobox exists), Inspur (four inconsistent dates because "Inspur" is not one organisation), Adept (the circulating "2022" traces to the phrase "founded two years ago"), NAVER AI Lab (no date on NAVER's own page for it). A null with a documented search distinguishes "we looked and could not find" from "we did not consider this".

## Cross-source check

An organisation cannot be credited on an Epoch frontier model published before it existed. Founding dates and Epoch publication dates come from independent sources, so a violation means one is wrong — and neither looks wrong alone. Same move that found the PointNet id collision last session.

Measured, not asserted: exercises **22 of 46 rows**, and is not vacuous — tightest margin is Google DeepMind, founded 2023-04-20 with its first flagged model 2023-12-06, so a founding date wrong by a year fires it.

## Traps recorded in the rows so nobody re-finds them

- **DeepMind's Sept/Nov ambiguity runs opposite to the usual telling.** Incorporated 2010-09-23 as the shelf company `FRIARS 2022 LIMITED`, renamed 2010-11-15. September is "a legal entity exists"; November is "DeepMind exists".
- **Compaq CRL was founded by DEC**, not Compaq. The Epoch org string flattens a three-parent lineage.
- **Qwen is not in DAMO Academy** — it moved to Alibaba Cloud's Tongyi Lab in late 2022.
- **Character.AI and Adept were reverse-acquihires**, not acquisitions. Status stays `active`, `parent_org` null.
- **Two decoy corporate records rejected and named**: a UK `REKA AI LTD.` in Altrincham that isn't the Sunnyvale lab, and a wrong SIREN for Mistral that circulates in secondary write-ups.
- **AI21 downgraded against the researcher's finding** — Wikipedia's cited source for "November 2017" contains no founding date when followed through.

## Honest weak spot

14 of 46 rows rest on secondary sources rather than a register or first-party statement, usually because the organisation is an internal division with no incorporation record. Upgrading those is the next pass. Image, video and robotics labs are under-represented, since Epoch's coverage skews to language models with published compute.

## Open question for the owner

The curated rows live under `data/enrichment/frontier_labs/` alongside `human_review/`, because both are human-produced input the build merges in. The alternative is a new `data/curated/` zone — that's a DATA_ZONES decision and deliberately not made unilaterally.

Refs #37