### PR TITLE
docs: Stop owning cross-repo print conventions; defer to coordination

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,44 @@ Python with `io.open(..., encoding="utf-8", newline="\n")`.
 - **Licence enforcement is mechanical, not remembered.** `validate_candidate()`
   refuses any dump whose SPDX contains `-SA`.
 
+## Cross-repo conventions are NOT owned here
+
+**Before inventing any printing, dictation, memo or routing convention, read
+`PipFoweraker/coordination` -> `PRINT_AND_PROCESS_REFERENCE.md`.** It is the
+canonical file and it is maintained by the coordination seat.
+
+This is not advice. On 2026-07-31 three repositories independently built print
+and dictation tooling on the same day, and two independently debugged the same
+printer bug hours apart. **pdoom-data was one of the three.** The tooling in
+`tools/print/` and `docs/PRINT_STYLE_GUIDE.md` is that duplication; it is
+pending deletion (coordination#2, ask A1) in favour of
+`coordination/tools/walkpack/build_walkpack.py`.
+
+Facts from that reference worth having before you touch a printer from here:
+
+- The Brother HL-L2460DW is a **host-based raster printer**. It accepts
+  `image/urf` and `image/pwg-raster` only -- **no PDF, no PostScript, no PCL**.
+  Sending a PDF to port 9100 prints a ream of ASCII garbage.
+- **Use SumatraPDF** with `-print-to ... -silent -exit-when-done`. It is not
+  installed on this seat.
+- **`Start-Process -Verb Print` fails on this seat**: `.pdf` has no registered
+  handler at all. Documented; do not rediscover it.
+- **Verify on the spooler, not on the exit code**, and poll fast -- jobs drain
+  in under five seconds and `JobCountSinceLastReset` reads 0 regardless. A
+  single late poll looks identical to a failed print, and reporting "cannot
+  print" on that basis has already cost Pip a walk to the machine.
+- **Checklists and runsheets print simplex.** A back face hides half the
+  checklist when the sheet is clipped.
+- Every printed artifact carries a boxed `PRINTED <day> <date> <time> <tz>`, a
+  staleness line, `supersedes:`, and hand-typed `PAGE n OF m` -- Chromium
+  cannot generate page numbers, so they must be written into the source.
+- **Qualify every issue reference with its repo** (`pdoom1#630`, not `#630`).
+  A bare number costs Pip a context switch.
+
+Routing: data contracts and standards live here. Game, release and league go to
+`pdoom1`; site and publishing to `pdoom1-website`; cross-repo daily ops,
+printing and capture to `coordination`.
+
 ## Where to look
 
     docs/DOCUMENTATION_INDEX.md   navigation hub, start here

--- a/docs/PRINT_STYLE_GUIDE.md
+++ b/docs/PRINT_STYLE_GUIDE.md
@@ -1,5 +1,28 @@
 # Print packet style guide
 
+> **SUPERSEDED, pending deletion. Do not build on this.**
+>
+> The canonical reference is `PipFoweraker/coordination` ->
+> `PRINT_AND_PROCESS_REFERENCE.md`, with tooling at
+> `coordination/tools/walkpack/build_walkpack.py`. This file was written on
+> 2026-07-31 in ignorance of it, and is one of three print systems three
+> repositories built independently that day.
+>
+> Deletion is pending only on coordination#2 ask A1. Until then it is kept so
+> the reference-code convention below can be compared against theirs rather
+> than lost silently.
+>
+> **What this file got wrong**, measured against the canonical reference:
+> it advertises "A4 or Letter" where the queue default is Letter and AU work
+> must pass `paper=A4` per job; it has no boxed `PRINTED` timestamp, so a
+> reprint cannot be distinguished from an original -- a failure that cost Pip
+> re-answered questions on 2026-07-31; no staleness line; no `supersedes:`;
+> and no hand-typed `PAGE n OF m`, which the canonical reference calls
+> load-bearing because Chromium cannot generate page numbers and a clipped
+> stack must reveal a missing page. It also treats sides as a preference when
+> the reference makes it a correctness rule: checklists and runsheets print
+> **simplex**, because a back face hides half the checklist on a clipboard.
+
 For documents that get **printed, carried, annotated and dictated against**.
 Pip reads these on walks, away from screens, on a clipboard. Screen rendering is
 the secondary case, and the design is optimised accordingly.


### PR DESCRIPTION
pdoom-data was **one of the three repositories** that independently built print and dictation tooling on 2026-07-31 — the incident named in the header of `coordination/PRINT_AND_PROCESS_REFERENCE.md`. The canonical reference already existed and this seat did not know.

`CLAUDE.md` now says so before anything else about printing, with the facts inline that cost this session time to rediscover — the printer is host-based raster and accepts no PDF; `Start-Process -Verb Print` fails here because `.pdf` has no handler; verify on the spooler and poll fast, because jobs drain in under five seconds and `JobCountSinceLastReset` reads 0 regardless; checklists print simplex.

That last poll detail is why I told Pip I could not print when the job had almost certainly succeeded — the same failure shape as `pdoom1#1075`.

`docs/PRINT_STYLE_GUIDE.md` is banner-marked SUPERSEDED with what it got wrong measured against the canonical file, rather than quietly left to be found and followed. Deletion pends only coordination#2 ask A1.

The rule this encodes: **a convention that crosses repositories is not this repository's to invent.**

Refs coordination#2.