### PR TITLE
fix: Correct the check rule -- it is input from outside, not output from inside

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,10 +185,34 @@ the orphaned-collection problem as E-0, with numbers matching a later
 independent measurement exactly. Found, written down, not acted on. The failure
 was never detection.
 
-**A check must take at least one output from inside the system it is
-checking.** Endorsed by Pip. The related rule from `pdoom1-website#229`:
-monitoring by polling is not merely incomplete but incapable -- state has to be
-pushed.
+**A check must take at least one INPUT FROM OUTSIDE the system it is
+checking.** Endorsed by Pip; canonical wording is `pdoom1#1075`, restored by
+`coordination#5`. **Cite the source, do not paraphrase** -- this seat wrote it
+here backwards as "output from inside" on 2026-08-02 and propagated the
+inverted form into three repos and two printed sheets before it was caught.
+The inversion is not cosmetic: the inverted form passes the exact failure the
+rule was written to catch.
+
+Two clauses, and a single-clause version passes one instance and fails the
+other:
+
+1. **Observe the system's actual state**, not a proxy for it. An `ssh` cleanup
+   trusted on its exit code returns 0 on an SFTP-only host having executed
+   nothing.
+2. **Do not derive what to look for from that same system.** A board probe that
+   built its candidate list from seeds the site had already seen could not see
+   a newly drawn seed, by construction. Fix per `pdoom1-website#229`: read the
+   expectation from an artifact a different repo produced.
+
+Worked example from this repo, and note it cuts against the obvious fix: the
+redaction tool's verifier used a silently broken pattern and reported clean
+while ten records still carried addresses. Making detection and verification
+share one function satisfies clause 1 and **violates clause 2** -- a defect in
+the shared function is then invisible to both. What actually caught it was a
+separately written scanner giving a different answer.
+
+Related, same issue: monitoring by polling is not merely incomplete but
+incapable. State has to be pushed.
 
 Facts from that reference worth having before you touch a printer from here:
 


### PR DESCRIPTION
**Correction to section 6 of this contribution, before the formal postmortem uses it.**

I stated the league-day rule as *"a check must take at least one **output from inside** the system it is checking."* **That is inverted.** The source statement in pdoom1#1075 is *"at least one **input from outside**"*, and coordination PR #5 restored it on 2026-08-02 with Pip confirming the intended direction.

The inversion is not cosmetic. As PR #5 puts it, **the inverted form passes the exact failure it was written to catch** — a check reading only its own system's outputs is precisely the board probe that built its candidate-seed list from seeds the site had already seen, so a newly drawn seed was invisible by construction.

## The rule needs both clauses

PR #5 also records why, because the instances behind it fail in two different ways:

**Observe the system's actual state.** The `ssh` cleanup was trusted on its exit code rather than on whether the files were gone; an SFTP-only host returns 0 having executed nothing. Fix: curl the live site.

**Do not derive what to look for from that same system.** The board probe *did* observe the live API, but built its expectations from it. Fix per pdoom1-website#229: read the seed from the release artifact, produced by a different repo.

A single-clause version stated either way passes one of these and fails the other.

## What this does to my own example

I offered my redaction-tool bug as a clean instance of the rule, and said the fix was to make detection and verification **share one function**. Against the corrected two-clause rule, **that fix is right for the first clause and wrong for the second.**

Sharing one function guarantees the verifier can see what the detector sees — good. But it also means a defect in the shared function is invisible to both, which is the second clause's failure exactly. My pattern was silently broken; a shared-function design would have hidden that just as thoroughly.

What actually caught it was not the shared function. It was running a **separately written raw-text scanner** over the output and getting a different answer — an input from outside. The final verification used two independently authored tools reporting zero, and that is the shape worth generalising, not the shared function.

So my own example supports the corrected rule better than it supported the version I stated, and I had drawn the wrong lesson from it. Worth saying plainly since the postmortem was going to inherit it.

## Where else this went

The inverted form is in `pdoom-data/CLAUDE.md` (being corrected now), in coordination#2, and in two printed sheets from 2026-08-02. All from this seat. Anyone who took the phrasing from me rather than from pdoom1#1075 has the wrong one.

That is itself the postmortem's document-versus-mechanism point: I propagated a *statement* of a rule faster than anyone could check it against its source, and the statement was backwards. The mechanism version would have been a pointer to pdoom1#1075 instead of a paraphrase.

Refs pdoom1#1075, pdoom1-website#229, coordination#5, coordination#9.
