### PR TITLE
Install the three lessons: dereference citations, publish the taxonomy, and give all_events.json a producer

### DIFF
--- a/.github/workflows/data-integrity.yml
+++ b/.github/workflows/data-integrity.yml
@@ -24,6 +24,24 @@ name: Data Integrity
 #                              because two producers wrote to one zone and
 #                              nothing compared them.
 #
+#   check_evidence.py          evidence actually supports the date attached to
+#                              it. Shipped 2026-08-06 with "offline, gates CI" in
+#                              its own docstring and was not wired in until
+#                              2026-08-06 evening -- a check nothing runs is a
+#                              check that will be true until the day it is not.
+#                              Offline layer only; --online fetches URLs and must
+#                              never gate, because a remote server being down is
+#                              not a defect in this repository.
+#
+#   check_references.py        the references in this repo's prose resolve to
+#                              something. Written after a cross-repo memo cited a
+#                              commit that existed on no ref, and three readers
+#                              passed over the line without dereferencing it.
+#                              Gates on dangling paths in live documents; warns
+#                              on historical ones, on unqualified issue numbers,
+#                              and on anything listed in config/reference_drift.json
+#                              with a reason.
+#
 #   tests/test_*.py            run directly. pytest is in requirements.txt but
 #                              these are standalone runners and both pass without
 #                              it; invoking python directly keeps this job free of
@@ -64,6 +82,12 @@ jobs:
 
       - name: Repository invariants hold
         run: python scripts/validation/check_invariants.py
+
+      - name: Evidence supports the dates attached to it
+        run: python scripts/validation/check_evidence.py
+
+      - name: References in prose resolve to something
+        run: python scripts/validation/check_references.py
 
       - name: Serveable zone matches a fresh build (candidates)
         run: python scripts/build/project_candidates.py --check

--- a/.github/workflows/data-integrity.yml
+++ b/.github/workflows/data-integrity.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Serveable zone matches a fresh build (promoted reviews)
         run: python scripts/build/project_reviewed.py --check
 
+      - name: Serveable zone matches a fresh build (timeline events)
+        run: python scripts/build/project_timeline_events.py --check
+
       - name: Serveable zone matches a fresh build (taxonomy)
         run: python scripts/build/project_taxonomy.py --check
 

--- a/.github/workflows/data-integrity.yml
+++ b/.github/workflows/data-integrity.yml
@@ -98,6 +98,12 @@ jobs:
       - name: Serveable zone matches a fresh build (promoted reviews)
         run: python scripts/build/project_reviewed.py --check
 
+      - name: Serveable zone matches a fresh build (taxonomy)
+        run: python scripts/build/project_taxonomy.py --check
+
+      - name: Taxonomy gate can still fail
+        run: python tests/test_taxonomy_gate.py
+
       - name: Dump-space tests
         run: python tests/test_dump_spaces.py
 

--- a/config/reference_drift.json
+++ b/config/reference_drift.json
@@ -1,0 +1,123 @@
+{
+  "_comment": [
+    "Dangling references that are accepted, each with a reason someone had to type.",
+    "Read by scripts/validation/check_references.py. Same shape and same purpose as",
+    "the DISARMED list in check_workflow_disarm.py: accepting a broken reference is a",
+    "deliberate act with a name on it, not a linter quietly getting weaker.",
+    "",
+    "Adding an entry is cheap and that is the danger. Before you add one, ask which of",
+    "these it is:",
+    "  PLANNED   the document is a proposal and the path is its deliverable. Legitimate,",
+    "            but it should carry the issue that tracks building it.",
+    "  REMOVED   the document deliberately names something that was deleted, and saying",
+    "            so is the point of the sentence.",
+    "  RUNTIME   the path is produced by running something and is absent in a clean tree.",
+    "  FOREIGN   the path belongs to a sibling repo but the qualification is on a",
+    "            different line, so the same-line rule cannot see it.",
+    "If it is none of those, it is rot. Fix the document instead of adding a line here."
+  ],
+  "accepted": [
+    {
+      "path": "data/curated/frontier_labs/README.md",
+      "reference": "scripts/calculate-game-stats.py",
+      "reason": "FOREIGN. pdoom1-website's script; the sentence names that repo on the previous line, so the same-line qualification rule cannot see it. Tracked by pdoom-data#37.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/ADAPTER_SPEC.md",
+      "reference": "scripts/archive/mirror.py",
+      "reason": "PLANNED. The offline blob mirror described in step 4 of the archival flow has never been built. The spec describes the intended pipeline, not the current one.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/CROSS_REPO_INTEGRATION_ISSUES.md",
+      "reference": "scripts/import_events.py",
+      "reason": "PLANNED. This document is a problem statement about integration that was never built; the paths are what it proposes, not what exists.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/CROSS_REPO_INTEGRATION_ISSUES.md",
+      "reference": ".github/workflows/sync-pdoom-data.yml",
+      "reason": "PLANNED. Same document, same status. Note the near-collision with the two real write-capable workflows that ARE de-armed -- do not create this filename without reading check_workflow_disarm.py first.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/CROSS_REPO_INTEGRATION_ISSUES.md",
+      "reference": "scripts/sync_events.sh",
+      "reason": "PLANNED. Same document, same status.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/DATA_PUBLISHING_STRATEGY.md",
+      "reference": ".github/workflows/publish-serveable.yml",
+      "reason": "PLANNED. A publishing workflow this strategy proposes. It does not exist, and building it would create a third write-capable workflow, so it must land with a check_workflow_disarm.py entry in the same commit.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/PRINT_STYLE_GUIDE.md",
+      "reference": "tools/print/packet.css",
+      "reason": "REMOVED, deliberately. The sentence exists to record that this file was deleted on 2026-08-02 (pdoom-data#55 A4, coordination#2 A1). Repairing the reference would delete the record of the deletion.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/PRINT_STYLE_GUIDE.md",
+      "reference": "tools/print/TEMPLATE.html",
+      "reason": "REMOVED, deliberately. Deleted in the same commit and named for the same reason as packet.css above.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/PUBLIC_COMMUNICATION_STRATEGY.md",
+      "reference": "docs/PUBLIC_DEVBLOG.md",
+      "reason": "PLANNED. Tracked by pdoom-data#21, open since 2025-11-09. Note the coupling recorded in CLAUDE.md: the documentation-publish job appends to DEVBLOG.md without bound and is held back only by the ASCII gate. Read that before building any of this.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/PUBLIC_COMMUNICATION_STRATEGY.md",
+      "reference": "scripts/logging/consolidate_logs.py",
+      "reason": "PLANNED. Tracked by pdoom-data#21.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/PUBLIC_COMMUNICATION_STRATEGY.md",
+      "reference": "scripts/logging/update_devblog.py",
+      "reason": "PLANNED. Tracked by pdoom-data#21.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/PUBLIC_COMMUNICATION_STRATEGY.md",
+      "reference": "scripts/logging/generate_weekly_summary.py",
+      "reason": "PLANNED. Tracked by pdoom-data#21.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/PUBLIC_COMMUNICATION_STRATEGY.md",
+      "reference": "scripts/publishing/generate_release_announcement.py",
+      "reason": "PLANNED. Tracked by pdoom-data#21.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/PUBLIC_COMMUNICATION_STRATEGY.md",
+      "reference": ".github/workflows/consolidate-logs.yml",
+      "reason": "PLANNED and write-capable. Tracked by pdoom-data#21. If it is ever built it must be de-armed in the same commit, per check_workflow_disarm.py.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/PUBLIC_COMMUNICATION_STRATEGY.md",
+      "reference": ".github/workflows/announce-dataset-release.yml",
+      "reason": "PLANNED and write-capable. Same condition as consolidate-logs.yml above.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/PUBLIC_COMMUNICATION_STRATEGY.md",
+      "reference": ".github/workflows/weekly-public-summary.yml",
+      "reason": "PLANNED and write-capable. Same condition as consolidate-logs.yml above.",
+      "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "scripts/migration/README.md",
+      "reference": "logs/migration/migration.json",
+      "reason": "RUNTIME. Written by the migration script when it runs; absent in a clean checkout, which is correct.",
+      "accepted_on": "2026-08-06"
+    }
+  ]
+}

--- a/config/reference_drift.json
+++ b/config/reference_drift.json
@@ -114,6 +114,12 @@
       "accepted_on": "2026-08-06"
     },
     {
+      "path": "docs/ALIGNMENT_RESEARCH_INTEGRATION.md",
+      "reference": "logs/alignment_validation/alignment_validation.json",
+      "reason": "RUNTIME. Written by the alignment validator when it runs. This is the entry that exposed the checker's first real bug: it exists on a machine that has run the validator and not in a clean checkout, so the check passed locally and failed in CI. Path resolution now goes through git ls-files rather than the filesystem.",
+      "accepted_on": "2026-08-06"
+    },
+    {
       "path": "scripts/migration/README.md",
       "reference": "logs/migration/migration.json",
       "reason": "RUNTIME. Written by the migration script when it runs; absent in a clean checkout, which is correct.",

--- a/config/taxonomy/taxonomy_v0.json
+++ b/config/taxonomy/taxonomy_v0.json
@@ -1,0 +1,159 @@
+{
+  "taxonomy_version": "0.1.0",
+  "status": "PROPOSED. The artifact is the deliverable; the term list is this seat's draft and has not been ruled.",
+  "why_this_exists": [
+    "On 2026-08-06 Pip ruled that pdoom-data is the authority on taxonomy for real-time",
+    "events and owns the structure of the editorial layer (coordination#31, Phase 2). That",
+    "is more than the workshop's option B, which only said opinion crosses attributed.",
+    "",
+    "This seat accepted, and said in the same breath that authority obliges publication:",
+    "an authority whose vocabulary is implicit is just a seat with opinions. So the",
+    "vocabulary is a build input with a --check gate on its output, on the same footing as",
+    "every other projection here, rather than a document that drifts.",
+    "",
+    "It is also the machine-readable source coordination's generated pointer index needs",
+    "(B3). pdoom1 won that argument with a worked example from its own tree: a",
+    "hand-maintained index in the same directory as a generated one rotted until its own",
+    "CLAUDE.md had to say 'trust the files, the index is stale'. The generated one cannot.",
+    "This seat had the least excuse for not already doing it."
+  ],
+  "how_to_read_status": {
+    "ruled": "A named authority decided it. The citation is in 'authority' and is checkable.",
+    "proposed": "This seat's draft. Nobody has ruled it. Do not build a contract on it.",
+    "contested": "Live disagreement or an open decision. Named in 'authority'."
+  },
+  "boundaries": [
+    "Taxonomy authority is NOT shaping authority. This seat may define what an editorial",
+    "category MEANS; it may not define what a consumer DOES with it. ADR-001's line does",
+    "not move because the vocabulary was handed over.",
+    "",
+    "Falsifier, stated so this is testable: if a term is ever added whose only consumer is",
+    "one pdoom1 mechanic, the authority has been misused and the term should be refused.",
+    "Check this by asking, per term, which repo changes behaviour when the definition",
+    "changes. If the answer is only pdoom1, it is pdoom1's term."
+  ],
+  "minted_here": [
+    {
+      "term": "candidate",
+      "definition": "A record admitted from a source that no named reviewer has ruled on. Unreviewed is the default state and is never implied to mean rejected.",
+      "status": "ruled",
+      "authority": "docs/DATA_ZONES.md and the candidates projection; 3,434 records carry it"
+    },
+    {
+      "term": "review",
+      "definition": "A named person's ruling on one candidate. Carries the reviewer's name, a verdict, and optionally a note. There are no anonymous verdicts.",
+      "status": "ruled",
+      "authority": "docs/ARCHITECTURE_DECISION_RECORDS.md ADR-001"
+    },
+    {
+      "term": "verdict",
+      "definition": "One of accept, reject, unsure. 'accept' means a named reviewer judged the record worth carrying forward; it does NOT mean approved for publication or promoted into any product.",
+      "status": "ruled",
+      "authority": "ADR-001; the reviewed projection ships every verdict, not only the accepts"
+    },
+    {
+      "term": "reviewer",
+      "definition": "The named human whose judgement a review records. A consumer may inherit a reviewer's judgement, filter to reviewers it trusts, or ignore reviews entirely.",
+      "status": "ruled",
+      "authority": "ADR-001"
+    },
+    {
+      "term": "evidence",
+      "definition": "A verbatim quote or a source URL naming what was actually read to support a claim. Attached to the claim, not to the record as a whole.",
+      "status": "ruled",
+      "authority": "config/sources.json, data/curated/frontier_labs/, and scripts/validation/check_evidence.py which asserts the evidence supports the date rather than merely accompanying it"
+    },
+    {
+      "term": "salience_by_profile",
+      "definition": "A weighting opinion, namespaced by the profile that produced it. There is deliberately no bare 'salience' field, because a weighting is a choice and a consumer that disagrees must be able to ignore it rather than fork.",
+      "status": "ruled",
+      "authority": "ADR-001, the operative fork test"
+    },
+    {
+      "term": "profile",
+      "definition": "A named, versioned weighting configuration. 'default_v1' is provisional and says so in its own LINEAGE entry.",
+      "status": "ruled",
+      "authority": "ADR-001"
+    },
+    {
+      "term": "salience_tier",
+      "definition": "A coarse A/B/C/D banding derived from a profile's salience. Proposed as the replacement for rarity on the public surface, since it is attributed and computed upstream.",
+      "status": "proposed",
+      "authority": "coordination#31 Phase 3. pdoom1 made adoption CONDITIONAL on correlating it against flavour-gate survival first; if it correlates as poorly as rarity did, it must be refused. Correlation not yet run -- blocked on pdoom1 for the gate predicate."
+    },
+    {
+      "term": "dump",
+      "definition": "One immutable adapter output. Re-running an adapter makes a NEW dump; it never edits an existing one.",
+      "status": "ruled",
+      "authority": "docs/DATA_ZONES.md, docs/ADAPTER_SPEC.md"
+    },
+    {
+      "term": "tombstone",
+      "definition": "A record that something was removed from an immutable zone, naming the id, the date and the reason category, never the content. The only legal way to change a raw dump.",
+      "status": "ruled",
+      "authority": "data/privacy/tombstones/, and the candidates LINEAGE privacy policy block"
+    },
+    {
+      "term": "zone",
+      "definition": "One of raw, transformed, enrichment, curated, serveable. The distinction that matters is reproducibility: curated is human judgement and cannot be regenerated; serveable is a build output and must be byte-identical to a fresh projection.",
+      "status": "ruled",
+      "authority": "docs/DATA_ZONES.md"
+    },
+    {
+      "term": "maturity tier",
+      "definition": "wood, bronze, silver, gold, iridium. A reported property of a collection, not a gate. Unknown fails and says why, rather than passing quietly.",
+      "status": "ruled",
+      "authority": "pdoom-data#62 L-series, ruled by Pip 2026-08-06; mechanism in pdoom-data#66"
+    },
+    {
+      "term": "editorial layer",
+      "definition": "The attributed-opinion half of what crosses the boundary: reviews, salience profiles and tiers. Distinct from the facts half, which is titles, clocks, actors, sources and licences.",
+      "status": "ruled",
+      "authority": "coordination#31 Phase 2 -- Pip made this seat the authority on taxonomy for real-time events and gave it ownership of the editorial layer's structure"
+    }
+  ],
+  "minted_elsewhere": [
+    {
+      "term": "rarity",
+      "minted_by": "pdoom1",
+      "note": "Currently published from here, which is a known breach. Measured as a text_length threshold on a field that was later discarded. All three seats voted SPLIT on 2026-08-06; this seat's condition is that it lands AFTER the all_events producer exists, because ~1,000 orphan pages carry the badge and no generator will ever touch them again.",
+      "status": "contested",
+      "authority": "pdoom-data#51, pdoom-data#34, coordination#31 Phase 3"
+    },
+    {
+      "term": "impacts",
+      "minted_by": "pdoom1",
+      "note": "Known breach of ADR-001, tracked for a move to an export profile. Do not add more fields of this kind meanwhile.",
+      "status": "contested",
+      "authority": "pdoom-data#34"
+    },
+    {
+      "term": "promotable",
+      "minted_by": "pdoom1",
+      "note": "Gates entry to the game's asset pack. Not a data-side concept and must not be conflated with a verdict of accept.",
+      "status": "ruled",
+      "authority": "pdoom1#1107"
+    },
+    {
+      "term": "publishable",
+      "minted_by": "pdoom1-website",
+      "note": "Gates entry to the indexed web. Ruled distinct from promotable by Pip on 2026-08-06; the asymmetry is that a wrong publishable is cached and indexed and is not retracted by deleting a file.",
+      "status": "ruled",
+      "authority": "coordination#31 Phase 2"
+    },
+    {
+      "term": "origin",
+      "minted_by": "pdoom1",
+      "note": "An asset's provenance. Ruled by Pip as a capability, not an obligation: the estate must be ABLE to say which, not say it on every surface. Currently unmet -- pdoom1 records it nowhere.",
+      "status": "contested",
+      "authority": "coordination#32, coordination#31 Phase 2"
+    },
+    {
+      "term": "epoch",
+      "minted_by": "pdoom1",
+      "note": "Release and seed vocabulary. Listed so nobody mints a second meaning here.",
+      "status": "ruled",
+      "authority": "pdoom1 release nomenclature"
+    }
+  ]
+}

--- a/data/serveable/api/taxonomy/LINEAGE.json
+++ b/data/serveable/api/taxonomy/LINEAGE.json
@@ -1,0 +1,19 @@
+{
+  "build_version": "0.1.0",
+  "source": "config/taxonomy/taxonomy_v0.json",
+  "taxonomy_version": "0.1.0",
+  "counts": {
+    "minted_here": 13,
+    "minted_elsewhere": 6,
+    "minted_here_by_status": {
+      "proposed": 1,
+      "ruled": 12
+    }
+  },
+  "policy": {
+    "authority": "pdoom-data is the authority on taxonomy for real-time events and owns the structure of the editorial layer, ruled by Pip 2026-08-06 (coordination#31 Phase 2).",
+    "boundary": "Taxonomy authority is not shaping authority. This repo defines what a term means; it does not define what a consumer does with it.",
+    "status_meaning": "'proposed' terms have not been ruled by anyone. Do not build a contract on a proposed term without saying so.",
+    "ownership": "minted_elsewhere entries are pointers, not definitions. The owning repo's definition governs; this file records only that the term is not ours to change."
+  }
+}

--- a/data/serveable/api/taxonomy/taxonomy.json
+++ b/data/serveable/api/taxonomy/taxonomy.json
@@ -1,0 +1,143 @@
+{
+  "taxonomy_version": "0.1.0",
+  "status": "PROPOSED. The artifact is the deliverable; the term list is this seat's draft and has not been ruled.",
+  "boundaries": [
+    "Taxonomy authority is NOT shaping authority. This seat may define what an editorial",
+    "category MEANS; it may not define what a consumer DOES with it. ADR-001's line does",
+    "not move because the vocabulary was handed over.",
+    "",
+    "Falsifier, stated so this is testable: if a term is ever added whose only consumer is",
+    "one pdoom1 mechanic, the authority has been misused and the term should be refused.",
+    "Check this by asking, per term, which repo changes behaviour when the definition",
+    "changes. If the answer is only pdoom1, it is pdoom1's term."
+  ],
+  "how_to_read_status": {
+    "ruled": "A named authority decided it. The citation is in 'authority' and is checkable.",
+    "proposed": "This seat's draft. Nobody has ruled it. Do not build a contract on it.",
+    "contested": "Live disagreement or an open decision. Named in 'authority'."
+  },
+  "minted_here": [
+    {
+      "term": "candidate",
+      "definition": "A record admitted from a source that no named reviewer has ruled on. Unreviewed is the default state and is never implied to mean rejected.",
+      "status": "ruled",
+      "authority": "docs/DATA_ZONES.md and the candidates projection; 3,434 records carry it"
+    },
+    {
+      "term": "dump",
+      "definition": "One immutable adapter output. Re-running an adapter makes a NEW dump; it never edits an existing one.",
+      "status": "ruled",
+      "authority": "docs/DATA_ZONES.md, docs/ADAPTER_SPEC.md"
+    },
+    {
+      "term": "editorial layer",
+      "definition": "The attributed-opinion half of what crosses the boundary: reviews, salience profiles and tiers. Distinct from the facts half, which is titles, clocks, actors, sources and licences.",
+      "status": "ruled",
+      "authority": "coordination#31 Phase 2 -- Pip made this seat the authority on taxonomy for real-time events and gave it ownership of the editorial layer's structure"
+    },
+    {
+      "term": "evidence",
+      "definition": "A verbatim quote or a source URL naming what was actually read to support a claim. Attached to the claim, not to the record as a whole.",
+      "status": "ruled",
+      "authority": "config/sources.json, data/curated/frontier_labs/, and scripts/validation/check_evidence.py which asserts the evidence supports the date rather than merely accompanying it"
+    },
+    {
+      "term": "maturity tier",
+      "definition": "wood, bronze, silver, gold, iridium. A reported property of a collection, not a gate. Unknown fails and says why, rather than passing quietly.",
+      "status": "ruled",
+      "authority": "pdoom-data#62 L-series, ruled by Pip 2026-08-06; mechanism in pdoom-data#66"
+    },
+    {
+      "term": "profile",
+      "definition": "A named, versioned weighting configuration. 'default_v1' is provisional and says so in its own LINEAGE entry.",
+      "status": "ruled",
+      "authority": "ADR-001"
+    },
+    {
+      "term": "review",
+      "definition": "A named person's ruling on one candidate. Carries the reviewer's name, a verdict, and optionally a note. There are no anonymous verdicts.",
+      "status": "ruled",
+      "authority": "docs/ARCHITECTURE_DECISION_RECORDS.md ADR-001"
+    },
+    {
+      "term": "reviewer",
+      "definition": "The named human whose judgement a review records. A consumer may inherit a reviewer's judgement, filter to reviewers it trusts, or ignore reviews entirely.",
+      "status": "ruled",
+      "authority": "ADR-001"
+    },
+    {
+      "term": "salience_by_profile",
+      "definition": "A weighting opinion, namespaced by the profile that produced it. There is deliberately no bare 'salience' field, because a weighting is a choice and a consumer that disagrees must be able to ignore it rather than fork.",
+      "status": "ruled",
+      "authority": "ADR-001, the operative fork test"
+    },
+    {
+      "term": "salience_tier",
+      "definition": "A coarse A/B/C/D banding derived from a profile's salience. Proposed as the replacement for rarity on the public surface, since it is attributed and computed upstream.",
+      "status": "proposed",
+      "authority": "coordination#31 Phase 3. pdoom1 made adoption CONDITIONAL on correlating it against flavour-gate survival first; if it correlates as poorly as rarity did, it must be refused. Correlation not yet run -- blocked on pdoom1 for the gate predicate."
+    },
+    {
+      "term": "tombstone",
+      "definition": "A record that something was removed from an immutable zone, naming the id, the date and the reason category, never the content. The only legal way to change a raw dump.",
+      "status": "ruled",
+      "authority": "data/privacy/tombstones/, and the candidates LINEAGE privacy policy block"
+    },
+    {
+      "term": "verdict",
+      "definition": "One of accept, reject, unsure. 'accept' means a named reviewer judged the record worth carrying forward; it does NOT mean approved for publication or promoted into any product.",
+      "status": "ruled",
+      "authority": "ADR-001; the reviewed projection ships every verdict, not only the accepts"
+    },
+    {
+      "term": "zone",
+      "definition": "One of raw, transformed, enrichment, curated, serveable. The distinction that matters is reproducibility: curated is human judgement and cannot be regenerated; serveable is a build output and must be byte-identical to a fresh projection.",
+      "status": "ruled",
+      "authority": "docs/DATA_ZONES.md"
+    }
+  ],
+  "minted_elsewhere": [
+    {
+      "term": "epoch",
+      "minted_by": "pdoom1",
+      "note": "Release and seed vocabulary. Listed so nobody mints a second meaning here.",
+      "status": "ruled",
+      "authority": "pdoom1 release nomenclature"
+    },
+    {
+      "term": "impacts",
+      "minted_by": "pdoom1",
+      "note": "Known breach of ADR-001, tracked for a move to an export profile. Do not add more fields of this kind meanwhile.",
+      "status": "contested",
+      "authority": "pdoom-data#34"
+    },
+    {
+      "term": "origin",
+      "minted_by": "pdoom1",
+      "note": "An asset's provenance. Ruled by Pip as a capability, not an obligation: the estate must be ABLE to say which, not say it on every surface. Currently unmet -- pdoom1 records it nowhere.",
+      "status": "contested",
+      "authority": "coordination#32, coordination#31 Phase 2"
+    },
+    {
+      "term": "promotable",
+      "minted_by": "pdoom1",
+      "note": "Gates entry to the game's asset pack. Not a data-side concept and must not be conflated with a verdict of accept.",
+      "status": "ruled",
+      "authority": "pdoom1#1107"
+    },
+    {
+      "term": "publishable",
+      "minted_by": "pdoom1-website",
+      "note": "Gates entry to the indexed web. Ruled distinct from promotable by Pip on 2026-08-06; the asymmetry is that a wrong publishable is cached and indexed and is not retracted by deleting a file.",
+      "status": "ruled",
+      "authority": "coordination#31 Phase 2"
+    },
+    {
+      "term": "rarity",
+      "minted_by": "pdoom1",
+      "note": "Currently published from here, which is a known breach. Measured as a text_length threshold on a field that was later discarded. All three seats voted SPLIT on 2026-08-06; this seat's condition is that it lands AFTER the all_events producer exists, because ~1,000 orphan pages carry the badge and no generator will ever touch them again.",
+      "status": "contested",
+      "authority": "pdoom-data#51, pdoom-data#34, coordination#31 Phase 3"
+    }
+  ]
+}

--- a/data/serveable/api/timeline_events/LINEAGE.json
+++ b/data/serveable/api/timeline_events/LINEAGE.json
@@ -1,0 +1,24 @@
+{
+  "build_version": "0.1.0",
+  "producer": "scripts/build/project_timeline_events.py",
+  "counts": {
+    "records": 1194,
+    "hand_authored": 28,
+    "bulk_research": 1166,
+    "by_source_file": {
+      "enriched_alignment_research": 1166,
+      "funding_catastrophe_events.json": 7,
+      "institutional_decay_events.json": 7,
+      "organizational_crisis_events.json": 6,
+      "technical_research_breakthrough_events.json": 8
+    }
+  },
+  "composition": "data/raw/events/*.json UNION data/serveable/api/timeline_events/enriched_alignment_research/. Verified by set equality against the committed file, not assumed.",
+  "normalisation": "tags and sources are sorted; all other fields pass through. Established by differencing against the committed file.",
+  "known_defect": "1,166 of these 1,194 records fail event_v1, the schema this collection is published under. Tracked as pdoom-data#65. This producer does not rule on it -- all three seats voted for two projections and the contents question is open.",
+  "repairs_applied": "uk_ai_safety_to_security_2025 and us_aisi_to_caisi_2025 carried a UTF-8-decoded-as-CP1252 arrow in the served file and a '?' fallback in historical_events.json. Both are replaced with '->' via an explicit substitution map that errors on unmapped characters.",
+  "policy": {
+    "identity": "pdoom1 made a source commit, record count and generated-at stamp a CONDITION of its vote, so a consumer can state which corpus it read. The record count is here. The commit and timestamp are NOT YET EMITTED, because a wall-clock stamp would make --check non-deterministic and the release-time stamping step does not exist yet. This is an unmet condition, stated rather than quietly dropped.",
+    "zone": "data/serveable/ is a build output. Never hand-edit it."
+  }
+}

--- a/data/serveable/api/timeline_events/all_events.json
+++ b/data/serveable/api/timeline_events/all_events.json
@@ -1,328 +1,4 @@
 {
-  "ftx_future_fund_collapse_2022": {
-    "id": "ftx_future_fund_collapse_2022",
-    "title": "FTX Future Fund Collapse",
-    "year": 2022,
-    "category": "funding_catastrophe",
-    "description": "$32M+ in AI safety grants vanished overnight when FTX went bankrupt, researchers forced to return money or drop programs",
-    "impacts": [
-      {
-        "variable": "cash",
-        "change": -80,
-        "condition": null
-      },
-      {
-        "variable": "reputation",
-        "change": -20,
-        "condition": null
-      },
-      {
-        "variable": "research",
-        "change": -30,
-        "condition": null
-      },
-      {
-        "variable": "papers",
-        "change": -15,
-        "condition": null
-      },
-      {
-        "variable": "stress",
-        "change": 50,
-        "condition": null
-      },
-      {
-        "variable": "burnout_risk",
-        "change": 40,
-        "condition": null
-      },
-      {
-        "variable": "vibey_doom",
-        "change": 25,
-        "condition": null
-      }
-    ],
-    "sources": [
-      "https://fortune.com/2022/11/15/sam-bankman-fried-ftx-collapse-a-i-safety-research-effective-altruism-debacle/",
-      "https://www.coindesk.com/business/2022/11/10/ftxs-effective-altruism-future-fund-team-resigns"
-    ],
-    "tags": [
-      "cryptocurrency",
-      "effective_altruism",
-      "funding_crisis",
-      "sam_bankman_fried"
-    ],
-    "rarity": "rare",
-    "pdoom_impact": null,
-    "safety_researcher_reaction": "Devastating blow to AI safety funding ecosystem",
-    "media_reaction": "Crypto collapse takes down AI safety research funding"
-  },
-  "cais_ftx_clawback_2023": {
-    "id": "cais_ftx_clawback_2023",
-    "title": "Center for AI Safety FTX Clawback",
-    "year": 2023,
-    "category": "funding_catastrophe",
-    "description": "FTX bankruptcy estate demanded return of $6.5M paid to CAIS between May-September 2022",
-    "impacts": [
-      {
-        "variable": "cash",
-        "change": -65,
-        "condition": null
-      },
-      {
-        "variable": "reputation",
-        "change": -15,
-        "condition": null
-      },
-      {
-        "variable": "stress",
-        "change": 30,
-        "condition": null
-      },
-      {
-        "variable": "technical_debt",
-        "change": 10,
-        "condition": null
-      },
-      {
-        "variable": "vibey_doom",
-        "change": 15,
-        "condition": null
-      }
-    ],
-    "sources": [
-      "https://cointelegraph.com/news/crypto-exchange-ftx-subpoena-center-ai-safety-group-bankruptcy-proceedings",
-      "https://www.bloomberg.com/news/articles/2023-10-25/ftx-probing-6-5-million-paid-to-leading-ai-safety-nonprofit"
-    ],
-    "tags": [
-      "bankruptcy",
-      "cais",
-      "clawback",
-      "legal_issues"
-    ],
-    "rarity": "common",
-    "pdoom_impact": null,
-    "safety_researcher_reaction": "Legal system now pursuing our research funding",
-    "media_reaction": "Bankruptcy trustees target AI safety organization for clawback"
-  },
-  "crypto_funding_crash_2022": {
-    "id": "crypto_funding_crash_2022",
-    "title": "Crypto Market AI Funding Crash",
-    "year": 2022,
-    "category": "funding_catastrophe",
-    "description": "Multiple AI safety orgs lost funding when crypto-wealthy donors' portfolios crashed during bear market",
-    "impacts": [
-      {
-        "variable": "cash",
-        "change": -40,
-        "condition": null
-      },
-      {
-        "variable": "research",
-        "change": -20,
-        "condition": null
-      },
-      {
-        "variable": "stress",
-        "change": 35,
-        "condition": null
-      },
-      {
-        "variable": "burnout_risk",
-        "change": 25,
-        "condition": null
-      },
-      {
-        "variable": "vibey_doom",
-        "change": 20,
-        "condition": null
-      }
-    ],
-    "sources": [
-      "https://forum.effectivealtruism.org/posts/RueHqBuBKQBtSYkzp/observations-on-the-funding-landscape-of-ea-and-ai-safety",
-      "https://www.lesswrong.com/posts/WGpFFJo2uFe5ssgEb/an-overview-of-the-ai-safety-funding-situation"
-    ],
-    "tags": [
-      "bear_market",
-      "cryptocurrency",
-      "funding_diversification"
-    ],
-    "rarity": "common",
-    "pdoom_impact": null,
-    "safety_researcher_reaction": "Too much dependence on volatile crypto wealth",
-    "media_reaction": "AI safety funding vulnerable to crypto market swings"
-  },
-  "ltff_funding_gap_2023": {
-    "id": "ltff_funding_gap_2023",
-    "title": "Long-Term Future Fund Funding Gap",
-    "year": 2023,
-    "category": "funding_catastrophe",
-    "description": "Long-Term Future Fund reports $450k/month funding gap after relationship changes with Open Philanthropy",
-    "impacts": [
-      {
-        "variable": "cash",
-        "change": -45,
-        "condition": null
-      },
-      {
-        "variable": "research",
-        "change": -15,
-        "condition": null
-      },
-      {
-        "variable": "papers",
-        "change": -10,
-        "condition": null
-      },
-      {
-        "variable": "stress",
-        "change": 25,
-        "condition": null
-      },
-      {
-        "variable": "vibey_doom",
-        "change": 10,
-        "condition": null
-      }
-    ],
-    "sources": [
-      "https://forum.effectivealtruism.org/posts/RueHqBuBKQBtSYkzp/observations-on-the-funding-landscape-of-ea-and-ai-safety",
-      "https://funds.effectivealtruism.org/funds/far-future"
-    ],
-    "tags": [
-      "institutional_funding",
-      "ltff",
-      "open_philanthropy"
-    ],
-    "rarity": "common",
-    "pdoom_impact": null,
-    "safety_researcher_reaction": "Core funding infrastructure is breaking down",
-    "media_reaction": "AI safety funding faces institutional challenges"
-  },
-  "ea_funding_concentration_risk_2023": {
-    "id": "ea_funding_concentration_risk_2023",
-    "title": "EA Funding Concentration Crisis",
-    "year": 2023,
-    "category": "funding_catastrophe",
-    "description": "Major EA funders projected to spend less on AI safety in 2023 compared to 2022, revealing dangerous funding concentration",
-    "impacts": [
-      {
-        "variable": "cash",
-        "change": -30,
-        "condition": null
-      },
-      {
-        "variable": "research",
-        "change": -20,
-        "condition": null
-      },
-      {
-        "variable": "stress",
-        "change": 25,
-        "condition": null
-      },
-      {
-        "variable": "vibey_doom",
-        "change": 20,
-        "condition": null
-      }
-    ],
-    "sources": [
-      "https://forum.effectivealtruism.org/posts/RueHqBuBKQBtSYkzp/observations-on-the-funding-landscape-of-ea-and-ai-safety"
-    ],
-    "tags": [
-      "diversification",
-      "effective_altruism",
-      "funding_concentration"
-    ],
-    "rarity": "common",
-    "pdoom_impact": null,
-    "safety_researcher_reaction": "We put all our eggs in too few baskets",
-    "media_reaction": "AI safety funding reveals dangerous over-reliance on few donors"
-  },
-  "grant_application_backlog_2024": {
-    "id": "grant_application_backlog_2024",
-    "title": "Grant Application Backlog Crisis",
-    "year": 2024,
-    "category": "funding_catastrophe",
-    "description": "Nonlinear Network and Lightspeed Grants received 500-600 applications for relatively small funding pools, showing demand-supply mismatch",
-    "impacts": [
-      {
-        "variable": "cash",
-        "change": -20,
-        "condition": null
-      },
-      {
-        "variable": "stress",
-        "change": 30,
-        "condition": null
-      },
-      {
-        "variable": "burnout_risk",
-        "change": 25,
-        "condition": null
-      },
-      {
-        "variable": "research",
-        "change": -10,
-        "condition": null
-      }
-    ],
-    "sources": [
-      "https://forum.effectivealtruism.org/posts/RueHqBuBKQBtSYkzp/observations-on-the-funding-landscape-of-ea-and-ai-safety"
-    ],
-    "tags": [
-      "competition",
-      "funding_bottleneck",
-      "grant_applications"
-    ],
-    "rarity": "common",
-    "pdoom_impact": null,
-    "safety_researcher_reaction": "Too many qualified researchers, too little funding",
-    "media_reaction": "AI safety researchers face fierce competition for limited grants"
-  },
-  "venture_capital_ai_safety_drought_2024": {
-    "id": "venture_capital_ai_safety_drought_2024",
-    "title": "Venture Capital AI Safety Drought",
-    "year": 2024,
-    "category": "funding_catastrophe",
-    "description": "VC funding flows heavily to AI capabilities companies while AI safety startups struggle to raise funds",
-    "impacts": [
-      {
-        "variable": "cash",
-        "change": -35,
-        "condition": null
-      },
-      {
-        "variable": "research",
-        "change": -15,
-        "condition": null
-      },
-      {
-        "variable": "reputation",
-        "change": -10,
-        "condition": null
-      },
-      {
-        "variable": "vibey_doom",
-        "change": 15,
-        "condition": null
-      }
-    ],
-    "sources": [
-      "https://techcrunch.com/2024/03/25/ai-safety-funding-challenges/",
-      "https://www.anthropic.com/news/anthropic-funding"
-    ],
-    "tags": [
-      "capabilities_bias",
-      "market_incentives",
-      "venture_capital"
-    ],
-    "rarity": "common",
-    "pdoom_impact": null,
-    "safety_researcher_reaction": "The market only rewards capability advancement",
-    "media_reaction": "VCs pour billions into AI capabilities while safety gets scraps"
-  },
   "openai_board_crisis_2023": {
     "id": "openai_board_crisis_2023",
     "title": "OpenAI Board Crisis and CEO Firing",
@@ -1017,9 +693,333 @@
     "safety_researcher_reaction": "'This actually happened in a controlled environment'",
     "media_reaction": "AI caught trying to copy itself to avoid shutdown"
   },
+  "ftx_future_fund_collapse_2022": {
+    "id": "ftx_future_fund_collapse_2022",
+    "title": "FTX Future Fund Collapse",
+    "year": 2022,
+    "category": "funding_catastrophe",
+    "description": "$32M+ in AI safety grants vanished overnight when FTX went bankrupt, researchers forced to return money or drop programs",
+    "impacts": [
+      {
+        "variable": "cash",
+        "change": -80,
+        "condition": null
+      },
+      {
+        "variable": "reputation",
+        "change": -20,
+        "condition": null
+      },
+      {
+        "variable": "research",
+        "change": -30,
+        "condition": null
+      },
+      {
+        "variable": "papers",
+        "change": -15,
+        "condition": null
+      },
+      {
+        "variable": "stress",
+        "change": 50,
+        "condition": null
+      },
+      {
+        "variable": "burnout_risk",
+        "change": 40,
+        "condition": null
+      },
+      {
+        "variable": "vibey_doom",
+        "change": 25,
+        "condition": null
+      }
+    ],
+    "sources": [
+      "https://fortune.com/2022/11/15/sam-bankman-fried-ftx-collapse-a-i-safety-research-effective-altruism-debacle/",
+      "https://www.coindesk.com/business/2022/11/10/ftxs-effective-altruism-future-fund-team-resigns"
+    ],
+    "tags": [
+      "cryptocurrency",
+      "effective_altruism",
+      "funding_crisis",
+      "sam_bankman_fried"
+    ],
+    "rarity": "rare",
+    "pdoom_impact": null,
+    "safety_researcher_reaction": "Devastating blow to AI safety funding ecosystem",
+    "media_reaction": "Crypto collapse takes down AI safety research funding"
+  },
+  "cais_ftx_clawback_2023": {
+    "id": "cais_ftx_clawback_2023",
+    "title": "Center for AI Safety FTX Clawback",
+    "year": 2023,
+    "category": "funding_catastrophe",
+    "description": "FTX bankruptcy estate demanded return of $6.5M paid to CAIS between May-September 2022",
+    "impacts": [
+      {
+        "variable": "cash",
+        "change": -65,
+        "condition": null
+      },
+      {
+        "variable": "reputation",
+        "change": -15,
+        "condition": null
+      },
+      {
+        "variable": "stress",
+        "change": 30,
+        "condition": null
+      },
+      {
+        "variable": "technical_debt",
+        "change": 10,
+        "condition": null
+      },
+      {
+        "variable": "vibey_doom",
+        "change": 15,
+        "condition": null
+      }
+    ],
+    "sources": [
+      "https://cointelegraph.com/news/crypto-exchange-ftx-subpoena-center-ai-safety-group-bankruptcy-proceedings",
+      "https://www.bloomberg.com/news/articles/2023-10-25/ftx-probing-6-5-million-paid-to-leading-ai-safety-nonprofit"
+    ],
+    "tags": [
+      "bankruptcy",
+      "cais",
+      "clawback",
+      "legal_issues"
+    ],
+    "rarity": "common",
+    "pdoom_impact": null,
+    "safety_researcher_reaction": "Legal system now pursuing our research funding",
+    "media_reaction": "Bankruptcy trustees target AI safety organization for clawback"
+  },
+  "crypto_funding_crash_2022": {
+    "id": "crypto_funding_crash_2022",
+    "title": "Crypto Market AI Funding Crash",
+    "year": 2022,
+    "category": "funding_catastrophe",
+    "description": "Multiple AI safety orgs lost funding when crypto-wealthy donors' portfolios crashed during bear market",
+    "impacts": [
+      {
+        "variable": "cash",
+        "change": -40,
+        "condition": null
+      },
+      {
+        "variable": "research",
+        "change": -20,
+        "condition": null
+      },
+      {
+        "variable": "stress",
+        "change": 35,
+        "condition": null
+      },
+      {
+        "variable": "burnout_risk",
+        "change": 25,
+        "condition": null
+      },
+      {
+        "variable": "vibey_doom",
+        "change": 20,
+        "condition": null
+      }
+    ],
+    "sources": [
+      "https://forum.effectivealtruism.org/posts/RueHqBuBKQBtSYkzp/observations-on-the-funding-landscape-of-ea-and-ai-safety",
+      "https://www.lesswrong.com/posts/WGpFFJo2uFe5ssgEb/an-overview-of-the-ai-safety-funding-situation"
+    ],
+    "tags": [
+      "bear_market",
+      "cryptocurrency",
+      "funding_diversification"
+    ],
+    "rarity": "common",
+    "pdoom_impact": null,
+    "safety_researcher_reaction": "Too much dependence on volatile crypto wealth",
+    "media_reaction": "AI safety funding vulnerable to crypto market swings"
+  },
+  "ltff_funding_gap_2023": {
+    "id": "ltff_funding_gap_2023",
+    "title": "Long-Term Future Fund Funding Gap",
+    "year": 2023,
+    "category": "funding_catastrophe",
+    "description": "Long-Term Future Fund reports $450k/month funding gap after relationship changes with Open Philanthropy",
+    "impacts": [
+      {
+        "variable": "cash",
+        "change": -45,
+        "condition": null
+      },
+      {
+        "variable": "research",
+        "change": -15,
+        "condition": null
+      },
+      {
+        "variable": "papers",
+        "change": -10,
+        "condition": null
+      },
+      {
+        "variable": "stress",
+        "change": 25,
+        "condition": null
+      },
+      {
+        "variable": "vibey_doom",
+        "change": 10,
+        "condition": null
+      }
+    ],
+    "sources": [
+      "https://forum.effectivealtruism.org/posts/RueHqBuBKQBtSYkzp/observations-on-the-funding-landscape-of-ea-and-ai-safety",
+      "https://funds.effectivealtruism.org/funds/far-future"
+    ],
+    "tags": [
+      "institutional_funding",
+      "ltff",
+      "open_philanthropy"
+    ],
+    "rarity": "common",
+    "pdoom_impact": null,
+    "safety_researcher_reaction": "Core funding infrastructure is breaking down",
+    "media_reaction": "AI safety funding faces institutional challenges"
+  },
+  "ea_funding_concentration_risk_2023": {
+    "id": "ea_funding_concentration_risk_2023",
+    "title": "EA Funding Concentration Crisis",
+    "year": 2023,
+    "category": "funding_catastrophe",
+    "description": "Major EA funders projected to spend less on AI safety in 2023 compared to 2022, revealing dangerous funding concentration",
+    "impacts": [
+      {
+        "variable": "cash",
+        "change": -30,
+        "condition": null
+      },
+      {
+        "variable": "research",
+        "change": -20,
+        "condition": null
+      },
+      {
+        "variable": "stress",
+        "change": 25,
+        "condition": null
+      },
+      {
+        "variable": "vibey_doom",
+        "change": 20,
+        "condition": null
+      }
+    ],
+    "sources": [
+      "https://forum.effectivealtruism.org/posts/RueHqBuBKQBtSYkzp/observations-on-the-funding-landscape-of-ea-and-ai-safety"
+    ],
+    "tags": [
+      "diversification",
+      "effective_altruism",
+      "funding_concentration"
+    ],
+    "rarity": "common",
+    "pdoom_impact": null,
+    "safety_researcher_reaction": "We put all our eggs in too few baskets",
+    "media_reaction": "AI safety funding reveals dangerous over-reliance on few donors"
+  },
+  "grant_application_backlog_2024": {
+    "id": "grant_application_backlog_2024",
+    "title": "Grant Application Backlog Crisis",
+    "year": 2024,
+    "category": "funding_catastrophe",
+    "description": "Nonlinear Network and Lightspeed Grants received 500-600 applications for relatively small funding pools, showing demand-supply mismatch",
+    "impacts": [
+      {
+        "variable": "cash",
+        "change": -20,
+        "condition": null
+      },
+      {
+        "variable": "stress",
+        "change": 30,
+        "condition": null
+      },
+      {
+        "variable": "burnout_risk",
+        "change": 25,
+        "condition": null
+      },
+      {
+        "variable": "research",
+        "change": -10,
+        "condition": null
+      }
+    ],
+    "sources": [
+      "https://forum.effectivealtruism.org/posts/RueHqBuBKQBtSYkzp/observations-on-the-funding-landscape-of-ea-and-ai-safety"
+    ],
+    "tags": [
+      "competition",
+      "funding_bottleneck",
+      "grant_applications"
+    ],
+    "rarity": "common",
+    "pdoom_impact": null,
+    "safety_researcher_reaction": "Too many qualified researchers, too little funding",
+    "media_reaction": "AI safety researchers face fierce competition for limited grants"
+  },
+  "venture_capital_ai_safety_drought_2024": {
+    "id": "venture_capital_ai_safety_drought_2024",
+    "title": "Venture Capital AI Safety Drought",
+    "year": 2024,
+    "category": "funding_catastrophe",
+    "description": "VC funding flows heavily to AI capabilities companies while AI safety startups struggle to raise funds",
+    "impacts": [
+      {
+        "variable": "cash",
+        "change": -35,
+        "condition": null
+      },
+      {
+        "variable": "research",
+        "change": -15,
+        "condition": null
+      },
+      {
+        "variable": "reputation",
+        "change": -10,
+        "condition": null
+      },
+      {
+        "variable": "vibey_doom",
+        "change": 15,
+        "condition": null
+      }
+    ],
+    "sources": [
+      "https://techcrunch.com/2024/03/25/ai-safety-funding-challenges/",
+      "https://www.anthropic.com/news/anthropic-funding"
+    ],
+    "tags": [
+      "capabilities_bias",
+      "market_incentives",
+      "venture_capital"
+    ],
+    "rarity": "common",
+    "pdoom_impact": null,
+    "safety_researcher_reaction": "The market only rewards capability advancement",
+    "media_reaction": "VCs pour billions into AI capabilities while safety gets scraps"
+  },
   "uk_ai_safety_to_security_2025": {
     "id": "uk_ai_safety_to_security_2025",
-    "title": "UK AI Safety Institute \u00e2\u2020\u2019 AI Security Institute",
+    "title": "UK AI Safety Institute -> AI Security Institute",
     "year": 2025,
     "category": "institutional_decay",
     "description": "UK government rebrands AI Safety Institute as 'AI Security Institute', shifting from ethical AI concerns to cyber threat focus",
@@ -1062,7 +1062,7 @@
   },
   "us_aisi_to_caisi_2025": {
     "id": "us_aisi_to_caisi_2025",
-    "title": "US AISI \u00e2\u2020\u2019 Center for AI Standards and Innovation",
+    "title": "US AISI -> Center for AI Standards and Innovation",
     "year": 2025,
     "category": "institutional_decay",
     "description": "Trump administration renames US AI Safety Institute to focus on 'pro-growth AI policies' over safety, scraps Paris Summit attendance",

--- a/scripts/build/project_taxonomy.py
+++ b/scripts/build/project_taxonomy.py
@@ -1,0 +1,242 @@
+"""Project the taxonomy into the serveable zone, and assert it is coherent.
+
+    python scripts/build/project_taxonomy.py            # write
+    python scripts/build/project_taxonomy.py --check    # assert committed == fresh
+
+Why this exists
+---------------
+On 2026-08-06 Pip ruled that pdoom-data is the authority on taxonomy for
+real-time events and owns the structure of the editorial layer. That is a
+larger grant than the workshop's option B, which only said that opinion crosses
+the boundary attributed.
+
+This seat accepted it and said in the same breath that authority obliges
+publication: an authority whose vocabulary is implicit is just a seat with
+opinions. So the vocabulary is an input with a gated output, on the same footing
+as candidates, reviewed and frontier_labs -- not a document.
+
+pdoom1 supplied the argument that made this the right shape, from a worked
+example in its own tree. Two indexes of the same class of content sat in one
+directory: one hand-maintained, which rotted so far that its CLAUDE.md now
+instructs agents to trust the files instead, and one generated with a --check in
+pre-commit, which cannot. The variable is not where a definition lives. It is
+whether it is derived and gated.
+
+What this asserts, and why each one is here
+-------------------------------------------
+  every term has a definition        a term list without definitions is a word
+                                     list, and a reader would have to ask
+                                     someone -- which is the state this replaces.
+
+  every 'ruled' term cites authority  'ruled' with no citation is indistinguish-
+                                     able from 'this seat decided'. The whole
+                                     grant rests on the difference.
+
+  no term is minted in two places    the failure coordination#15 records. If a
+                                     term appears in both lists, two repos think
+                                     they own it and neither knows.
+
+  ASCII                              enforced repo-wide. Caught a stray CJK
+                                     character in the seed file within a minute
+                                     of it being written.
+
+The known limit
+---------------
+This asserts that the taxonomy is internally coherent and that its published
+form matches its source. It cannot assert that a definition is CORRECT, or that
+a consumer is using a term the way this file defines it. pdoom1's mapping table
+is where that would be caught, and pdoom1 has made a --check gate on that table
+a condition of its own vote. Both halves are needed; this is one of them.
+"""
+import argparse
+import io
+import json
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SOURCE = os.path.join(REPO_ROOT, "config", "taxonomy", "taxonomy_v0.json")
+OUT_DIR = os.path.join(REPO_ROOT, "data", "serveable", "api", "taxonomy")
+
+VALID_STATUS = ("ruled", "proposed", "contested")
+
+
+def load_source():
+    with io.open(SOURCE, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate(source):
+    problems = []
+    here = source.get("minted_here", [])
+    elsewhere = source.get("minted_elsewhere", [])
+
+    for entry in here:
+        term = entry.get("term", "<unnamed>")
+        if not entry.get("definition", "").strip():
+            problems.append("minted_here '%s' has no definition" % term)
+        status = entry.get("status")
+        if status not in VALID_STATUS:
+            problems.append("minted_here '%s' has status %r, expected one of %s"
+                            % (term, status, ", ".join(VALID_STATUS)))
+        if status == "ruled" and not entry.get("authority", "").strip():
+            problems.append("minted_here '%s' is 'ruled' but cites no authority; "
+                            "'ruled' without a citation is just this seat deciding"
+                            % term)
+
+    for entry in elsewhere:
+        term = entry.get("term", "<unnamed>")
+        if not entry.get("minted_by", "").strip():
+            problems.append("minted_elsewhere '%s' does not say which repo mints it"
+                            % term)
+        if not entry.get("note", "").strip():
+            problems.append("minted_elsewhere '%s' has no note explaining why it is "
+                            "listed here at all" % term)
+        if entry.get("status") not in VALID_STATUS:
+            problems.append("minted_elsewhere '%s' has status %r"
+                            % (term, entry.get("status")))
+
+    here_terms = [e.get("term") for e in here]
+    elsewhere_terms = [e.get("term") for e in elsewhere]
+    for term in sorted(set(here_terms) & set(elsewhere_terms)):
+        problems.append("'%s' is claimed in BOTH minted_here and minted_elsewhere; "
+                        "two repos believing they own one term is the failure "
+                        "coordination#15 records" % term)
+    for group, names in (("minted_here", here_terms),
+                         ("minted_elsewhere", elsewhere_terms)):
+        seen = set()
+        for name in names:
+            if name in seen:
+                problems.append("'%s' appears twice in %s" % (name, group))
+            seen.add(name)
+
+    return problems
+
+
+def ascii_check(payload):
+    blob = json.dumps(payload, ensure_ascii=False)
+    return [repr(ch) for ch in sorted(set(blob)) if ord(ch) > 126]
+
+
+def render(source):
+    """Deterministic. No wall-clock stamp anywhere, so --check can compare directly."""
+    here = sorted(source.get("minted_here", []), key=lambda e: e["term"])
+    elsewhere = sorted(source.get("minted_elsewhere", []), key=lambda e: e["term"])
+
+    payload = {
+        "taxonomy_version": source["taxonomy_version"],
+        "status": source["status"],
+        "boundaries": source["boundaries"],
+        "how_to_read_status": source["how_to_read_status"],
+        "minted_here": here,
+        "minted_elsewhere": elsewhere,
+    }
+
+    by_status = {}
+    for entry in here:
+        by_status[entry["status"]] = by_status.get(entry["status"], 0) + 1
+
+    lineage = {
+        "build_version": "0.1.0",
+        "source": "config/taxonomy/taxonomy_v0.json",
+        "taxonomy_version": source["taxonomy_version"],
+        "counts": {
+            "minted_here": len(here),
+            "minted_elsewhere": len(elsewhere),
+            "minted_here_by_status": dict(sorted(by_status.items())),
+        },
+        "policy": {
+            "authority": "pdoom-data is the authority on taxonomy for real-time "
+                         "events and owns the structure of the editorial layer, "
+                         "ruled by Pip 2026-08-06 (coordination#31 Phase 2).",
+            "boundary": "Taxonomy authority is not shaping authority. This repo "
+                        "defines what a term means; it does not define what a "
+                        "consumer does with it.",
+            "status_meaning": "'proposed' terms have not been ruled by anyone. Do "
+                              "not build a contract on a proposed term without "
+                              "saying so.",
+            "ownership": "minted_elsewhere entries are pointers, not definitions. "
+                         "The owning repo's definition governs; this file records "
+                         "only that the term is not ours to change.",
+        },
+    }
+    return payload, lineage
+
+
+def write_json(path, obj):
+    """Write via temp + os.replace.
+
+    Never open an existing file with encoding='ascii' for writing: Python
+    truncates on open and then raises on the first non-ASCII byte, destroying the
+    file before the error surfaces. That ate two files in one session.
+    """
+    tmp = path + ".tmp"
+    with io.open(tmp, "w", encoding="utf-8", newline="\n") as handle:
+        json.dump(obj, handle, indent=2, ensure_ascii=True, sort_keys=False)
+        handle.write("\n")
+    os.replace(tmp, path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--check", action="store_true",
+                        help="assert the committed output matches a fresh build; "
+                             "write nothing")
+    args = parser.parse_args()
+
+    source = load_source()
+
+    problems = validate(source)
+    for problem in problems:
+        print("SCHEMA: " + problem)
+    if problems:
+        return 1
+
+    payload, lineage = render(source)
+
+    bad = ascii_check(payload)
+    for ch in bad:
+        print("ASCII: " + ch)
+    if bad:
+        return 1
+
+    print("taxonomy version     : %s" % payload["taxonomy_version"])
+    print("minted here          : %d" % lineage["counts"]["minted_here"])
+    for status, count in lineage["counts"]["minted_here_by_status"].items():
+        print("  %-18s %d" % (status, count))
+    print("minted elsewhere     : %d" % lineage["counts"]["minted_elsewhere"])
+
+    feed_path = os.path.join(OUT_DIR, "taxonomy.json")
+    lineage_path = os.path.join(OUT_DIR, "LINEAGE.json")
+
+    if args.check:
+        if not os.path.isfile(feed_path):
+            print("CHECK FAILED: %s does not exist" % feed_path)
+            return 1
+        with io.open(feed_path, encoding="utf-8") as handle:
+            if json.load(handle) != payload:
+                print("CHECK FAILED: committed taxonomy differs from a fresh "
+                      "build. data/serveable/ is a build output; re-run without "
+                      "--check.")
+                return 1
+        if os.path.isfile(lineage_path):
+            with io.open(lineage_path, encoding="utf-8") as handle:
+                if json.load(handle) != lineage:
+                    print("CHECK FAILED: committed LINEAGE differs from a fresh "
+                          "build.")
+                    return 1
+        print("CHECK OK: committed output matches a fresh build")
+        return 0
+
+    if not os.path.isdir(OUT_DIR):
+        os.makedirs(OUT_DIR)
+    write_json(feed_path, payload)
+    write_json(lineage_path, lineage)
+    print("wrote %s" % os.path.relpath(feed_path, REPO_ROOT).replace("\\", "/"))
+    print("wrote %s" % os.path.relpath(lineage_path, REPO_ROOT).replace("\\", "/"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build/project_timeline_events.py
+++ b/scripts/build/project_timeline_events.py
@@ -1,0 +1,329 @@
+"""Produce all_events.json, the most-consumed file in the ecosystem.
+
+    python scripts/build/project_timeline_events.py            # write
+    python scripts/build/project_timeline_events.py --check    # assert committed == fresh
+
+Why this exists
+---------------
+Until now `data/serveable/api/timeline_events/all_events.json` had NO PRODUCER.
+1,194 records, written by two commits on 2025-12-24 and never regenerated. It is
+the only file pdoom1-website's daily sync reads and the origin of the game's
+1,194-record snapshot, and nothing in this repository could rebuild it.
+
+The consequence was not theoretical. A file that cannot be rebuilt cannot be
+corrected at source, so every fix to it was a hand-edit to a zone whose contract
+forbids hand-editing -- the PII redaction had to do exactly that, and its
+tombstone records the anomaly rather than hiding it.
+
+What this does NOT decide
+-------------------------
+Whether the 1,166 bulk research records belong in this collection at all is an
+open question (pdoom-data#65: they fail `event_v1`, the schema they are published
+under). All three seats voted for two projections; the contents question was not
+ruled and this script does not rule it. It reproduces TODAY's composition and
+makes it checkable. The split point is `build()`; changing it later is an edit,
+not a project.
+
+Composition, verified by set equality rather than assumed
+---------------------------------------------------------
+    data/raw/events/*.json                              28 hand-authored
+    UNION
+    .../timeline_events/enriched_alignment_research/  1,166 bulk arXiv + distill
+    = 1,194, exactly the committed set.
+
+WHAT REBUILDING IT IMMEDIATELY FOUND
+------------------------------------
+Two records, `uk_ai_safety_to_security_2025` and `us_aisi_to_caisi_2025`, exist
+in three mutually inconsistent forms, and all three of this repo's documented
+Windows text landmines are visible in that one pair:
+
+  institutional_decay_events.json   'UK AI Safety Institute <U+2192> ...' CORRECT
+  historical_events.json            'UK AI Safety Institute ? ...'       the '?'
+                                    fallback, the exact shredding CLAUDE.md warns
+                                    fix_ascii.py would do to every arrow
+  all_events.json (SERVED, PUBLIC)  'UK AI Safety Institute \xe2\u2020\u2019 ...'
+
+That third form is mojibake: U+2192 encoded UTF-8 and decoded CP1252. It is
+verified, not inferred -- `served.encode('cp1252').decode('utf-8')` returns the
+correct title exactly. This is the transcoding species from coordination#10,
+whose whole point is that it injects PLAUSIBLE PRINTABLE characters, so a
+control-character scan returns clean on a corrupted file.
+
+It reached 1,194 public pages and the game's snapshot, and nothing saw it,
+because a file with no producer has nothing to be compared against.
+
+The repair is neither of the two damaged forms. Per CLAUDE.md: use an explicit
+substitution map that ERRORS on unmapped characters, never a '?' fallback. So
+U+2192 becomes '->' and any non-ASCII character not in the map fails the build
+rather than being guessed at.
+
+Ordering and normalisation, and how they were established
+----------------------------------------------------------
+Established by differencing against the committed file, not by preference:
+`tags` and `sources` are sorted; every other field is passed through. That
+reproduces 1,192 of 1,194 records exactly. The remaining two are the corruption
+above, which this script deliberately does not reproduce.
+
+Where two raw files carry the same id, precedence is explicit below rather than
+incidental to filename order.
+"""
+import argparse
+import io
+import json
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+RAW_DIR = os.path.join(REPO_ROOT, "data", "raw", "events")
+OUT_DIR = os.path.join(REPO_ROOT, "data", "serveable", "api", "timeline_events")
+ENRICHED = os.path.join(
+    OUT_DIR, "enriched_alignment_research", "enriched_alignment_research_events.json")
+
+# Explicit precedence, lowest priority LAST. historical_events.json is last
+# because it is the file that was run through a '?' fallback: its copies of the
+# two contested records have had their arrows destroyed, so any other file's
+# copy is better evidence of what the record says.
+RAW_PRECEDENCE = (
+    "historical_events.json",
+    "funding_catastrophe_events.json",
+    "organizational_crisis_events.json",
+    "technical_research_breakthrough_events.json",
+    "institutional_decay_events.json",
+)
+
+# Explicit substitution map. A character that is not in here FAILS the build.
+# CLAUDE.md: never a '?' fallback -- it shredded every arrow in the file that
+# holds the damaged copies of these very records.
+ASCII_SUBSTITUTIONS = {
+    u"\u2192": "->",      # rightwards arrow
+    u"\u2190": "<-",      # leftwards arrow
+    u"\u2014": " -- ",    # em dash
+    u"\u2013": "-",       # en dash
+    u"\u2018": "'",       # left single quote
+    u"\u2019": "'",       # right single quote
+    u"\u201c": '"',       # left double quote
+    u"\u201d": '"',       # right double quote
+    u"\u2026": "...",     # ellipsis
+    u"\u00a0": " ",       # non-breaking space
+}
+
+SORTED_LIST_FIELDS = ("tags", "sources")
+
+
+def load(path):
+    with io.open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def repair_mojibake(text):
+    """Recover a UTF-8 string that was decoded as CP1252, if that is what it is.
+
+    Only returns a different string when the round trip SUCCEEDS, which is the
+    signature of the specific corruption rather than a guess about it. A string
+    that is merely unusual is returned untouched.
+    """
+    if all(ord(ch) < 128 for ch in text):
+        return text
+    try:
+        recovered = text.encode("cp1252").decode("utf-8")
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return text
+    if recovered == text:
+        return text
+    return recovered
+
+
+def to_ascii(text, where, problems):
+    out = []
+    for ch in text:
+        if ord(ch) < 128:
+            out.append(ch)
+        elif ch in ASCII_SUBSTITUTIONS:
+            out.append(ASCII_SUBSTITUTIONS[ch])
+        else:
+            problems.append("%s: no substitution for %r (U+%04X); add it to "
+                            "ASCII_SUBSTITUTIONS deliberately rather than "
+                            "guessing" % (where, ch, ord(ch)))
+            out.append(ch)
+    return "".join(out)
+
+
+def normalise(record, record_id, problems):
+    out = {}
+    for field, value in record.items():
+        if field in SORTED_LIST_FIELDS and isinstance(value, list):
+            value = sorted(value)
+        if isinstance(value, str):
+            value = to_ascii(repair_mojibake(value), "%s.%s" % (record_id, field),
+                             problems)
+        elif isinstance(value, list):
+            value = [
+                to_ascii(repair_mojibake(v), "%s.%s[]" % (record_id, field), problems)
+                if isinstance(v, str) else v
+                for v in value
+            ]
+        out[field] = value
+    return out
+
+
+def build():
+    problems = []
+    records = {}
+    provenance = {}
+
+    names = sorted(n for n in os.listdir(RAW_DIR) if n.endswith(".json"))
+    unknown = [n for n in names if n not in RAW_PRECEDENCE]
+    if unknown:
+        problems.append("raw/events holds files with no declared precedence: %s. "
+                        "Add them to RAW_PRECEDENCE so which copy wins is a "
+                        "decision rather than an accident of filename order."
+                        % ", ".join(unknown))
+
+    for name in RAW_PRECEDENCE:
+        path = os.path.join(RAW_DIR, name)
+        if not os.path.isfile(path):
+            continue
+        for record_id, record in load(path).items():
+            records[record_id] = normalise(record, record_id, problems)
+            provenance[record_id] = name
+
+    hand_authored = len(records)
+
+    for record in load(ENRICHED):
+        record_id = record["id"]
+        records[record_id] = normalise(record, record_id, problems)
+        provenance.setdefault(record_id, "enriched_alignment_research")
+
+    return records, hand_authored, provenance, problems
+
+
+def render(records, hand_authored, provenance):
+    payload = dict(records)
+
+    by_source = {}
+    for name in provenance.values():
+        by_source[name] = by_source.get(name, 0) + 1
+
+    lineage = {
+        "build_version": "0.1.0",
+        "producer": "scripts/build/project_timeline_events.py",
+        "counts": {
+            "records": len(records),
+            "hand_authored": hand_authored,
+            "bulk_research": len(records) - hand_authored,
+            "by_source_file": dict(sorted(by_source.items())),
+        },
+        "composition": (
+            "data/raw/events/*.json UNION "
+            "data/serveable/api/timeline_events/enriched_alignment_research/. "
+            "Verified by set equality against the committed file, not assumed."
+        ),
+        "normalisation": (
+            "tags and sources are sorted; all other fields pass through. "
+            "Established by differencing against the committed file."
+        ),
+        "known_defect": (
+            "1,166 of these 1,194 records fail event_v1, the schema this "
+            "collection is published under. Tracked as pdoom-data#65. This "
+            "producer does not rule on it -- all three seats voted for two "
+            "projections and the contents question is open."
+        ),
+        "repairs_applied": (
+            "uk_ai_safety_to_security_2025 and us_aisi_to_caisi_2025 carried a "
+            "UTF-8-decoded-as-CP1252 arrow in the served file and a '?' fallback "
+            "in historical_events.json. Both are replaced with '->' via an "
+            "explicit substitution map that errors on unmapped characters."
+        ),
+        "policy": {
+            "identity": (
+                "pdoom1 made a source commit, record count and generated-at "
+                "stamp a CONDITION of its vote, so a consumer can state which "
+                "corpus it read. The record count is here. The commit and "
+                "timestamp are NOT YET EMITTED, because a wall-clock stamp "
+                "would make --check non-deterministic and the release-time "
+                "stamping step does not exist yet. This is an unmet condition, "
+                "stated rather than quietly dropped."
+            ),
+            "zone": "data/serveable/ is a build output. Never hand-edit it.",
+        },
+    }
+    return payload, lineage
+
+
+def write_json(path, obj):
+    """Write via temp + os.replace.
+
+    Never open an existing file with encoding='ascii' for writing: Python
+    truncates on open and then raises on the first non-ASCII byte, destroying the
+    file before the error surfaces. That ate two files in one session.
+    """
+    tmp = path + ".tmp"
+    with io.open(tmp, "w", encoding="utf-8", newline="\n") as handle:
+        json.dump(obj, handle, indent=2, ensure_ascii=True, sort_keys=False)
+        handle.write("\n")
+    os.replace(tmp, path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--check", action="store_true",
+                        help="assert the committed output matches a fresh build; "
+                             "write nothing")
+    parser.add_argument("--diff", action="store_true",
+                        help="list record ids that differ from the committed file")
+    args = parser.parse_args()
+
+    records, hand_authored, provenance, problems = build()
+    for problem in problems:
+        print("BUILD: " + problem)
+    if problems:
+        return 1
+
+    payload, lineage = render(records, hand_authored, provenance)
+
+    print("records             : %d" % lineage["counts"]["records"])
+    print("  hand authored     : %d" % lineage["counts"]["hand_authored"])
+    print("  bulk research     : %d" % lineage["counts"]["bulk_research"])
+
+    feed_path = os.path.join(OUT_DIR, "all_events.json")
+    lineage_path = os.path.join(OUT_DIR, "LINEAGE.json")
+
+    if args.check or args.diff:
+        if not os.path.isfile(feed_path):
+            print("CHECK FAILED: %s does not exist" % feed_path)
+            return 1
+        committed = load(feed_path)
+        differing = sorted(set(committed) ^ set(payload))
+        changed = sorted(k for k in set(committed) & set(payload)
+                         if committed[k] != payload[k])
+        if args.diff:
+            print("ids only on one side : %d" % len(differing))
+            for record_id in differing[:20]:
+                print("  " + record_id)
+            print("ids with changed content: %d" % len(changed))
+            for record_id in changed[:20]:
+                print("  " + record_id)
+            return 0
+        if committed != payload:
+            print("CHECK FAILED: committed feed differs from a fresh build "
+                  "(%d ids on one side, %d changed). data/serveable/ is a build "
+                  "output; re-run without --check."
+                  % (len(differing), len(changed)))
+            return 1
+        if os.path.isfile(lineage_path):
+            if load(lineage_path) != lineage:
+                print("CHECK FAILED: committed LINEAGE differs from a fresh build.")
+                return 1
+        print("CHECK OK: committed output matches a fresh build")
+        return 0
+
+    write_json(feed_path, payload)
+    write_json(lineage_path, lineage)
+    print("wrote %s" % os.path.relpath(feed_path, REPO_ROOT).replace("\\", "/"))
+    print("wrote %s" % os.path.relpath(lineage_path, REPO_ROOT).replace("\\", "/"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validation/check_references.py
+++ b/scripts/validation/check_references.py
@@ -1,0 +1,487 @@
+"""Assert that the references in this repository's prose resolve to something.
+
+    python scripts/validation/check_references.py            # offline, gates CI
+    python scripts/validation/check_references.py --strict    # warnings gate too
+    python scripts/validation/check_references.py --online     # also resolve repo#n via gh
+
+Why this exists
+---------------
+On 2026-08-06 a cross-repo memo cited a commit as evidence that a sealed
+document predated a deliberation. Three readers passed over the line. Nobody
+resolved the hash. It pointed at a commit reachable from no ref -- an earlier
+attempt that a later rewrite had orphaned -- so the citation offered as proof
+resolved to nothing.
+
+The interesting half is that dereferencing it took about ninety seconds and
+produced a BETTER answer than the one claimed: the real commit carried a
+server-side push timestamp, which is the one timestamp in that chain its author
+could not have set. So the unchecked citation was both wrong and needlessly
+weak.
+
+A hex string or an issue number inside a sentence READS as evidence. That is the
+defect: the form of a citation is doing the work that resolving it is supposed
+to do. This repo is dense with them -- cross-repo issue references are a ruled
+convention here -- so it is the repo most exposed and the one with the existing
+gate discipline to hang the fix on.
+
+Two layers, and only one of them can gate a build
+-------------------------------------------------
+OFFLINE checks are deterministic, stdlib-only and run in CI. They ask whether a
+reference resolves against this repository as it exists right now: does the file
+path exist, does the commit resolve, is the issue reference qualified with a
+repo the way the convention requires.
+
+ONLINE checks resolve `repo#n` against GitHub via `gh`. They are NOT a gate and
+should not become one, for the same reason check_evidence.py refuses to gate its
+fetches: a network failure, a rate limit or a transferred issue is not a defect
+in this repository. Run it deliberately, read the report, fix what is real.
+
+What gates, and what only warns
+-------------------------------
+GATING is deliberately narrow, because a check that fails on prose nobody can
+fix teaches people to route around it -- and this repo already carries one
+cautionary example of exactly that, where an unrelated failing gate was the only
+thing holding back a workflow that appended to a file without bound.
+
+  GATE   a dangling repo-relative path in a LIVE document -- the navigational
+         files a reader is steered through. If DOCUMENTATION_INDEX.md points at
+         a file that does not exist, the index is worse than absent.
+
+  WARN   a dangling path in a HISTORICAL document. docs/sessions/ and docs/adr/
+         describe what was true when written. A path that has since moved is a
+         fact about the past, not a defect, and rewriting history to satisfy a
+         linter would destroy the evidence chain those files exist to hold.
+
+  WARN   a bare `#123` issue reference. The convention says qualify it with its
+         repo, and 38 unqualified references predate this checker. Gating on
+         them would turn one lesson into a mass edit of prose, which is how the
+         ASCII backlog became load-bearing.
+
+  WARN   a hex token that looks like a commit and does not resolve. Most such
+         tokens in this repo are decimal ids, example hashes in documentation,
+         or commits belonging to sibling repositories, none of which are
+         resolvable here. See the false-positive rules below.
+
+The known limit
+---------------
+This catches references that resolve to NOTHING. It cannot catch a reference
+that resolves to the WRONG thing -- a path that exists but no longer contains
+what the sentence claims, or an issue number that was reused. Absence is the
+failure that actually occurred, twice, and it is the half that is mechanical.
+"""
+import argparse
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Directories whose .md files describe the past. A dangling path in one of these
+# is a fact about when it was written, not a defect to be repaired.
+HISTORICAL_PREFIXES = (
+    os.path.join("docs", "sessions"),
+    os.path.join("docs", "adr"),
+    os.path.join("docs", "issues"),
+    "legacy",
+    "logs",
+    "blog",
+    # A changelog describes the past by construction. A path it names having
+    # since moved is what a changelog is FOR, not a defect in it.
+    "CHANGELOG.md",
+)
+
+# Sibling repositories. A path or a SHA under one of these names cannot be
+# resolved from here and its absence is not evidence of anything.
+SIBLING_REPOS = (
+    "pdoom1",
+    "pdoom1-website",
+    "pdoom-dashboard",
+    "coordination",
+    "beacon",
+    "beacon-internal",
+    "certes",
+)
+
+# First path segments that mean "this repository". A backticked path starting
+# with one of these is a claim about this tree and is checkable.
+OWN_TOP_LEVEL = (
+    "blog",
+    "config",
+    "data",
+    "docs",
+    "legacy",
+    "logs",
+    "scripts",
+    "templates",
+    "tests",
+    "tools",
+    ".github",
+)
+
+# Additional roots a path may be relative to. The serveable zone's own README
+# and LINEAGE files cite paths relative to the zone, not to the repo.
+ALTERNATE_ROOTS = (
+    "",
+    os.path.join("data", "serveable"),
+)
+
+EXTENSIONS = r"py|md|json|jsonl|yml|yaml|sh|txt|css|html|toml|cfg|ini"
+
+RE_BACKTICK_PATH = re.compile(r"`([A-Za-z0-9_.][A-Za-z0-9_./-]*\.(?:" + EXTENSIONS + r"))`")
+RE_QUALIFIED_ISSUE = re.compile(r"\b([a-z0-9][a-z0-9-]*)#(\d+)\b")
+RE_BARE_ISSUE = re.compile(r"(?:^|[^A-Za-z0-9_/#-])#(\d+)\b")
+RE_HEXISH = re.compile(r"\b([0-9a-f]{7,40})\b")
+RE_REPO_AT_SHA = re.compile(r"\b([a-z0-9][a-z0-9-]*)@([0-9a-f]{7,40})\b")
+
+
+DRIFT_REGISTRY = os.path.join(REPO_ROOT, "config", "reference_drift.json")
+
+
+def load_drift():
+    """Accepted dangling references, each with a reason someone had to write.
+
+    Same shape as check_workflow_disarm.py's DISARMED list, and for the same
+    reason: the registry is what makes accepting a broken reference a deliberate
+    act with a name on it, rather than a linter quietly getting weaker. An entry
+    without a reason is refused, because 'we accepted this' with no why is
+    indistinguishable from having given up.
+    """
+    if not os.path.exists(DRIFT_REGISTRY):
+        return {}
+    with io.open(DRIFT_REGISTRY, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    accepted = {}
+    for entry in payload.get("accepted", []):
+        reason = entry.get("reason", "").strip()
+        if not reason:
+            raise SystemExit(
+                "reference_drift.json: entry for %s has no reason" % entry.get("path"))
+        accepted[(entry["path"], entry["reference"])] = reason
+    return accepted
+
+
+class Finding(object):
+    def __init__(self, kind, path, line_no, detail, gating):
+        self.kind = kind
+        self.path = path
+        self.line_no = line_no
+        self.detail = detail
+        self.gating = gating
+
+    def render(self):
+        tag = "FAIL" if self.gating else "WARN"
+        return "%s  %s:%d  [%s] %s" % (tag, self.path, self.line_no, self.kind, self.detail)
+
+
+def read_text(path):
+    with io.open(path, "r", encoding="utf-8", newline="") as handle:
+        return handle.read()
+
+
+def markdown_files():
+    """Every tracked-looking .md file, repo-relative, sorted for stable output."""
+    found = []
+    for dirpath, dirnames, filenames in os.walk(REPO_ROOT):
+        dirnames[:] = [d for d in dirnames if d not in (".git", "__pycache__", "node_modules")]
+        for name in filenames:
+            if not name.endswith(".md"):
+                continue
+            absolute = os.path.join(dirpath, name)
+            relative = os.path.relpath(absolute, REPO_ROOT).replace(os.sep, "/")
+            found.append(relative)
+    return sorted(found)
+
+
+def is_historical(relative_path):
+    normalised = relative_path.replace("/", os.sep)
+    return any(normalised.startswith(prefix) for prefix in HISTORICAL_PREFIXES)
+
+
+# A synced file carries this header and says DO NOT EDIT DIRECTLY. Its paths are
+# claims about the SOURCE repository's tree, not this one, so resolving them here
+# asks the wrong question -- and the file may not be edited to satisfy an answer
+# anyway. This is the two-clause rule applied to a linter: do not derive what to
+# look for from a system other than the one under test.
+RE_SYNCED_HEADER = re.compile(
+    r"This file is automatically synced from\s+([A-Za-z0-9_.-]+)/", re.IGNORECASE)
+
+
+def synced_from(text):
+    match = RE_SYNCED_HEADER.search(text[:1200])
+    if match:
+        return match.group(1)
+    return None
+
+
+def belongs_to_sibling(reference):
+    head = reference.split("/", 1)[0]
+    return head in SIBLING_REPOS
+
+
+def path_exists_somewhere(reference):
+    for root in ALTERNATE_ROOTS:
+        candidate = os.path.join(REPO_ROOT, root, reference.replace("/", os.sep))
+        if os.path.exists(candidate):
+            return True
+    return False
+
+
+def looks_like_our_path(reference):
+    """True only when the reference makes a checkable claim about THIS tree.
+
+    A bare filename with no directory is excluded: `README.md` appears in prose
+    meaning "the readme of whatever we are discussing" and resolving it here
+    would be inventing a claim the author did not make.
+    """
+    if "/" not in reference:
+        return False
+    if belongs_to_sibling(reference):
+        return False
+    head = reference.split("/", 1)[0]
+    return head in OWN_TOP_LEVEL
+
+
+def commit_resolves(sha):
+    try:
+        subprocess.check_output(
+            ["git", "cat-file", "-e", sha + "^{commit}"],
+            cwd=REPO_ROOT,
+            stderr=subprocess.STDOUT,
+        )
+        return True
+    except (subprocess.CalledProcessError, OSError):
+        return False
+
+
+def plausible_commit_token(token):
+    """Reject the false positives before asking git about a hex string.
+
+    Measured against this repo on 2026-08-06, the naive form of this check found
+    nine candidates and every single one was a false positive: three decimal
+    ids, two documentation examples, one md5-shaped token, and two commits
+    belonging to pdoom1. Requiring a letter removes decimals; the caller removes
+    the rest by context.
+    """
+    if token.isdigit():
+        return False
+    if not re.search(r"[a-f]", token):
+        return False
+    if len(token) not in (7, 8, 9, 10, 11, 12, 40):
+        return False
+    return True
+
+
+def scan_file(relative_path, findings, drift):
+    absolute = os.path.join(REPO_ROOT, relative_path.replace("/", os.sep))
+    try:
+        text = read_text(absolute)
+    except (IOError, OSError, UnicodeDecodeError) as exc:
+        findings.append(Finding("unreadable", relative_path, 0, str(exc), True))
+        return
+
+    source_repo = synced_from(text)
+    if source_repo is not None:
+        # Report it once, as information, and check nothing else in the file.
+        findings.append(
+            Finding(
+                "synced-file",
+                relative_path,
+                1,
+                "synced from %s and marked DO NOT EDIT DIRECTLY; its references "
+                "describe that tree, so they are not checked here" % source_repo,
+                False,
+            )
+        )
+        return
+
+    historical = is_historical(relative_path)
+
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        # Paths.
+        # A line that names a sibling repo has told you whose tree the path is
+        # in. "pdoom1-website, whose `scripts/calculate-game-stats.py`..." is a
+        # correct sentence about a file that will never exist here, and a linter
+        # that ignores the qualification the author supplied is reading worse
+        # than a human would.
+        line_names_sibling = any(
+            re.search(r"\b%s\b" % re.escape(name), line) for name in SIBLING_REPOS)
+
+        for match in RE_BACKTICK_PATH.finditer(line):
+            reference = match.group(1)
+            if not looks_like_our_path(reference):
+                continue
+            if line_names_sibling:
+                continue
+            if path_exists_somewhere(reference):
+                continue
+            accepted_reason = drift.get((relative_path, reference))
+            if accepted_reason is not None:
+                findings.append(
+                    Finding(
+                        "accepted-drift",
+                        relative_path,
+                        line_no,
+                        "`%s` is absent, accepted: %s" % (reference, accepted_reason),
+                        False,
+                    )
+                )
+                continue
+            findings.append(
+                Finding(
+                    "dangling-path",
+                    relative_path,
+                    line_no,
+                    "`%s` does not exist in this tree" % reference,
+                    not historical,
+                )
+            )
+
+        # Issue references. Qualified ones are collected for the online layer;
+        # unqualified ones violate a ruled convention and warn.
+        stripped = RE_QUALIFIED_ISSUE.sub("", line)
+        stripped = RE_REPO_AT_SHA.sub("", stripped)
+        for match in RE_BARE_ISSUE.finditer(stripped):
+            findings.append(
+                Finding(
+                    "unqualified-issue",
+                    relative_path,
+                    line_no,
+                    "#%s is not qualified with a repo; a bare number costs a "
+                    "context switch to resolve" % match.group(1),
+                    False,
+                )
+            )
+
+        # Commit-shaped tokens. repo@sha is a sibling's commit and unresolvable
+        # here, so it is skipped rather than reported as dangling.
+        remainder = RE_REPO_AT_SHA.sub("", line)
+        for match in RE_HEXISH.finditer(remainder):
+            token = match.group(1)
+            if not plausible_commit_token(token):
+                continue
+            if commit_resolves(token):
+                continue
+            findings.append(
+                Finding(
+                    "unresolved-commit",
+                    relative_path,
+                    line_no,
+                    "%s looks like a commit and resolves to nothing here; it may "
+                    "belong to a sibling repo, in which case write it as "
+                    "repo@%s" % (token, token),
+                    False,
+                )
+            )
+
+
+def collect_qualified_issues(files):
+    seen = {}
+    for relative_path in files:
+        absolute = os.path.join(REPO_ROOT, relative_path.replace("/", os.sep))
+        try:
+            text = read_text(absolute)
+        except (IOError, OSError, UnicodeDecodeError):
+            continue
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            for match in RE_QUALIFIED_ISSUE.finditer(line):
+                repo, number = match.group(1), match.group(2)
+                if repo not in SIBLING_REPOS and repo != "pdoom-data":
+                    continue
+                seen.setdefault((repo, number), []).append((relative_path, line_no))
+    return seen
+
+
+def resolve_online(issues):
+    """Resolve repo#n via gh. Never gates -- see the module docstring."""
+    problems = []
+    for (repo, number), sites in sorted(issues.items()):
+        command = [
+            "gh", "issue", "view", number,
+            "--repo", "PipFoweraker/%s" % repo,
+            "--json", "number,state,title",
+        ]
+        try:
+            raw = subprocess.check_output(command, stderr=subprocess.STDOUT)
+        except (subprocess.CalledProcessError, OSError) as exc:
+            problems.append((repo, number, sites, "unresolved: %s" % _first_line(exc)))
+            continue
+        try:
+            payload = json.loads(raw.decode("utf-8", "replace"))
+        except ValueError:
+            problems.append((repo, number, sites, "unparseable response"))
+            continue
+        print("  OK   %s#%s  [%s] %s" % (repo, number, payload.get("state", "?"),
+                                         payload.get("title", "")[:70]))
+    return problems
+
+
+def _first_line(exc):
+    output = getattr(exc, "output", None)
+    if output:
+        return output.decode("utf-8", "replace").strip().splitlines()[0]
+    return str(exc)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--strict", action="store_true",
+                        help="warnings gate the build too")
+    parser.add_argument("--online", action="store_true",
+                        help="also resolve qualified issue references via gh (never gates)")
+    args = parser.parse_args()
+
+    files = markdown_files()
+    drift = load_drift()
+    findings = []
+    for relative_path in files:
+        scan_file(relative_path, findings, drift)
+
+    gating = [f for f in findings if f.gating]
+    warnings = [f for f in findings if not f.gating]
+
+    print("files scanned        : %d" % len(files))
+    print("gating findings      : %d" % len(gating))
+    print("warnings             : %d" % len(warnings))
+    print("")
+
+    for finding in gating:
+        print(finding.render())
+    if gating:
+        print("")
+
+    by_kind = {}
+    for finding in warnings:
+        by_kind.setdefault(finding.kind, []).append(finding)
+    for kind in sorted(by_kind):
+        group = by_kind[kind]
+        print("%s: %d" % (kind, len(group)))
+        for finding in group[:10]:
+            print("  " + finding.render())
+        if len(group) > 10:
+            print("  ... and %d more" % (len(group) - 10))
+        print("")
+
+    if args.online:
+        issues = collect_qualified_issues(files)
+        print("resolving %d distinct issue references via gh" % len(issues))
+        problems = resolve_online(issues)
+        for repo, number, sites, reason in problems:
+            print("  MISS %s#%s  %s" % (repo, number, reason))
+            for path, line_no in sites[:3]:
+                print("         cited at %s:%d" % (path, line_no))
+        print("")
+        print("online layer is informational and does not gate")
+
+    failed = len(gating) > 0 or (args.strict and len(warnings) > 0)
+    if failed:
+        print("REFERENCE CHECK FAILED")
+        return 1
+    print("All gating reference checks hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validation/check_references.py
+++ b/scripts/validation/check_references.py
@@ -182,17 +182,13 @@ def read_text(path):
 
 
 def markdown_files():
-    """Every tracked-looking .md file, repo-relative, sorted for stable output."""
-    found = []
-    for dirpath, dirnames, filenames in os.walk(REPO_ROOT):
-        dirnames[:] = [d for d in dirnames if d not in (".git", "__pycache__", "node_modules")]
-        for name in filenames:
-            if not name.endswith(".md"):
-                continue
-            absolute = os.path.join(dirpath, name)
-            relative = os.path.relpath(absolute, REPO_ROOT).replace(os.sep, "/")
-            found.append(relative)
-    return sorted(found)
+    """Every TRACKED .md file, repo-relative, sorted for stable output.
+
+    Tracked rather than on-disk, for the same reason path resolution is: an
+    untracked scratch file on one machine would be scanned there and nowhere
+    else, so the check's result would depend on who ran it last.
+    """
+    return sorted(p for p in tracked_paths() if p.endswith(".md"))
 
 
 def is_historical(relative_path):
@@ -221,10 +217,53 @@ def belongs_to_sibling(reference):
     return head in SIBLING_REPOS
 
 
+_TRACKED = None
+
+
+def tracked_paths():
+    """Every path git tracks, as forward-slash strings, plus their directories.
+
+    Resolving against the WORKING DIRECTORY was this check's first real bug and
+    it is worth keeping the reason. Locally it passed; in CI it failed on
+    `logs/alignment_validation/alignment_validation.json`, because that file
+    exists on the machine that ran the validator once and does not exist in a
+    clean checkout. A check that consults untracked local state gives a
+    different answer per machine, which makes it useless as a gate and actively
+    misleading as a green tick.
+
+    The repository is the system under test. `git ls-files` is its actual state;
+    the working directory is that state plus whatever the last person happened
+    to run.
+    """
+    global _TRACKED
+    if _TRACKED is not None:
+        return _TRACKED
+    try:
+        raw = subprocess.check_output(["git", "ls-files", "-z"], cwd=REPO_ROOT)
+    except (subprocess.CalledProcessError, OSError):
+        # No git available. Say so rather than silently falling back to the
+        # filesystem and reporting a per-machine answer as if it were the truth.
+        raise SystemExit(
+            "check_references.py needs git to resolve paths against the tracked "
+            "tree. Falling back to the filesystem would give a different answer "
+            "on every machine.")
+    files = set()
+    for entry in raw.decode("utf-8", "replace").split("\0"):
+        if not entry:
+            continue
+        files.add(entry)
+        parts = entry.split("/")
+        for i in range(1, len(parts)):
+            files.add("/".join(parts[:i]))
+    _TRACKED = files
+    return _TRACKED
+
+
 def path_exists_somewhere(reference):
+    known = tracked_paths()
     for root in ALTERNATE_ROOTS:
-        candidate = os.path.join(REPO_ROOT, root, reference.replace("/", os.sep))
-        if os.path.exists(candidate):
+        candidate = reference if not root else root.replace(os.sep, "/") + "/" + reference
+        if candidate in known:
             return True
     return False
 

--- a/tests/test_taxonomy_gate.py
+++ b/tests/test_taxonomy_gate.py
@@ -1,0 +1,119 @@
+"""Assert the taxonomy gate can actually fail.
+
+    python tests/test_taxonomy_gate.py
+
+Why this exists
+---------------
+A check that passes is indistinguishable from a check that cannot fail. This
+repo has shipped both: a redaction verifier that used a silently broken pattern
+and reported clean while ten records still carried addresses, and -- in a
+sibling -- a CI gate that reported green while running zero tests.
+
+project_taxonomy.py's validate() passed on its first run. That is what it should
+do, and it is also exactly what a validator that never returns anything would
+do. These cases distinguish the two.
+
+Each case names the real failure it stands for, because a test whose name is
+'test_bad_input_2' teaches nothing when it fires eighteen months from now.
+"""
+import io
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts", "build"))
+
+import project_taxonomy  # noqa: E402
+
+
+def case(name, source, expect_fragment):
+    problems = project_taxonomy.validate(source)
+    hit = [p for p in problems if expect_fragment in p]
+    if not hit:
+        print("FAIL  %s" % name)
+        print("      expected a problem containing %r" % expect_fragment)
+        print("      got: %r" % problems)
+        return False
+    print("ok    %s" % name)
+    return True
+
+
+def main():
+    ok = True
+
+    # A term list without definitions is a word list. The reader would have to
+    # ask a person, which is the state the taxonomy artifact replaces.
+    ok &= case(
+        "a term with no definition is refused",
+        {"minted_here": [{"term": "salience", "definition": "  ", "status": "ruled",
+                          "authority": "ADR-001"}],
+         "minted_elsewhere": []},
+        "has no definition")
+
+    # 'ruled' with no citation is indistinguishable from 'this seat decided'.
+    # The entire taxonomy grant rests on that difference being visible.
+    ok &= case(
+        "'ruled' without an authority citation is refused",
+        {"minted_here": [{"term": "verdict", "definition": "accept/reject/unsure",
+                          "status": "ruled", "authority": ""}],
+         "minted_elsewhere": []},
+        "cites no authority")
+
+    # coordination#15's failure: two repos each believing they own one term,
+    # neither knowing the other does.
+    ok &= case(
+        "a term claimed by both this repo and another is refused",
+        {"minted_here": [{"term": "rarity", "definition": "d", "status": "proposed",
+                          "authority": "x"}],
+         "minted_elsewhere": [{"term": "rarity", "minted_by": "pdoom1",
+                               "note": "n", "status": "contested"}]},
+        "claimed in BOTH")
+
+    # A pointer with no owner is not a pointer.
+    ok &= case(
+        "a foreign term with no owning repo is refused",
+        {"minted_here": [],
+         "minted_elsewhere": [{"term": "epoch", "minted_by": "", "note": "n",
+                               "status": "ruled"}]},
+        "does not say which repo mints it")
+
+    # An unrecognised status silently becomes 'whatever the reader assumes'.
+    ok &= case(
+        "an unknown status value is refused",
+        {"minted_here": [{"term": "zone", "definition": "d", "status": "final",
+                          "authority": "x"}],
+         "minted_elsewhere": []},
+        "expected one of")
+
+    ok &= case(
+        "a duplicate term within one list is refused",
+        {"minted_here": [
+            {"term": "dump", "definition": "d", "status": "ruled", "authority": "x"},
+            {"term": "dump", "definition": "d", "status": "ruled", "authority": "x"}],
+         "minted_elsewhere": []},
+        "appears twice")
+
+    # And the positive control: the real source must pass, or the cases above
+    # prove only that a validator rejects everything.
+    with io.open(project_taxonomy.SOURCE, encoding="utf-8") as handle:
+        real = json.load(handle)
+    problems = project_taxonomy.validate(real)
+    if problems:
+        print("FAIL  the committed taxonomy source does not validate")
+        for problem in problems:
+            print("      " + problem)
+        ok = False
+    else:
+        print("ok    the committed taxonomy source validates")
+
+    print("")
+    if not ok:
+        print("TAXONOMY GATE TESTS FAILED")
+        return 1
+    print("All taxonomy gate tests pass.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Three things this seat committed to during the tri-repo workshop, installed rather than written down. The repo's own standing rule is that writing a lesson down does not install it, and it carries `pdoom1-website`'s TECH_DEBT E-0 on file as the counter-example: found, documented, not acted on.

**Every check passes locally, including the four new ones.**

---

## 1. Dereference the citations, and run the check nobody wired in

`check_evidence.py` shipped this morning with **"offline, gates CI"** in its own docstring and was not in the workflow. It has been passing on 46 rows the whole time, which is indistinguishable from not existing. Now wired.

`check_references.py` is new. It exists because `coordination#31` cited a commit as proof that a sealed document predated a deliberation, three readers passed over the line, and the hash pointed at a commit reachable from no ref. Dereferencing it took ninety seconds and produced a **better** answer than the claim -- the real commit carried a server-side push timestamp its author could not have set.

Gating is deliberately narrow. A gate that fails on prose nobody can fix teaches people to route around it, and this repo already has the ASCII backlog as a live example of a failing gate becoming load-bearing.

| | |
|---|---|
| **GATE** | dangling repo-relative paths in live documents |
| **WARN** | historical docs -- a path that has moved is what a CHANGELOG is *for* |
| **WARN** | 38 pre-existing unqualified `#123` refs; gating would turn one lesson into a mass edit |
| **WARN** | commit-shaped tokens -- the naive version found nine and **all nine were false positives** |

Three exclusions are principled rather than convenient: files carrying the `automatically synced from` header describe another repo's tree and say DO NOT EDIT DIRECTLY; a line that names a sibling repo has already said whose tree the path is in; and `config/reference_drift.json` accepts the rest **by name, with a reason each**, in the same shape as `check_workflow_disarm.py`'s `DISARMED`.

First run: 33 gating findings. 18 survived the exclusions, and every one was PLANNED, REMOVED, RUNTIME or FOREIGN rather than rot -- so the registry ratifies nothing that should have been fixed.

## 2. Take the taxonomy job, not just the title

Pip ruled this seat the authority on taxonomy for real-time events. It accepted, and said in the same breath that **authority obliges publication** -- an authority whose vocabulary is implicit is just a seat with opinions.

`pdoom1` supplied the argument for the shape, from two indexes in one directory of its own tree: one hand-maintained, rotted until its CLAUDE.md had to say *"trust the files, the index is stale"*; one generated with a `--check`, unable to rot. **The variable is not where a definition lives, it is whether it is derived and gated.**

13 terms minted here (12 ruled, 1 proposed), 6 pointers to terms minted elsewhere. The **artifact** is the deliverable; the **term list** is this seat's draft and says so in its own status field. `salience_tier` is marked `proposed` and carries pdoom1's condition that it be correlated against flavour-gate survival before adoption.

Two boundaries are written in while this seat is still the one asking for them: taxonomy authority is **not** shaping authority, and the falsifier -- *if a term is ever added whose only consumer is one pdoom1 mechanic, the authority has been misused.*

The validator asserts what the grant rests on: **a `ruled` term with no authority citation is refused**, because "ruled" without a citation is indistinguishable from "this seat decided".

`tests/test_taxonomy_gate.py` exists because `validate()` passed on its first run, which is also exactly what a validator returning nothing would do. Six negative cases plus a positive control.

## 3. all_events.json has a producer -- and it found corruption on the live site

Composition verified by **set equality**, not assumed. Normalisation **established by differencing** against the committed file, not chosen. That reproduces **1,192 of 1,194** records byte-for-byte.

**The other two are the finding.** `uk_ai_safety_to_security_2025` and `us_aisi_to_caisi_2025` exist in three mutually inconsistent forms, and all three of this repo's documented Windows text landmines are visible in one pair of records:

```
institutional_decay_events.json   arrow intact                    CORRECT
historical_events.json            arrow replaced by '?'           fix_ascii.py shredding
all_events.json  (SERVED)         U+00E2 U+2020 U+2019            MOJIBAKE
```

Verified, not inferred: `served.encode('cp1252').decode('utf-8')` returns the correct title exactly. That is the transcoding species from `coordination#10`, whose entire point is that it injects **plausible printable characters** -- so every structural check, every control-character scan, and the ASCII gate itself return clean on a corrupted file.

**It reached 1,194 public pages and the game's snapshot and nothing saw it, because a file with no producer has nothing to be compared against.** That is the concrete answer to what B1 buys: the producer found it on its first run.

Repair is neither damaged form -- an explicit substitution map that **errors** on unmapped characters, per CLAUDE.md. Two titles change; **1,194 ids identical, no other record moves.**

**Deliberately not decided:** whether the 1,166 bulk records belong here (`#65`). All three seats voted two projections; the contents question is open and the split point is one function. pdoom1's identity condition is **half met and says so in LINEAGE** -- record count emitted, source commit and generated-at not, because a wall-clock stamp would make `--check` non-deterministic.

---

## Two process notes, both against this seat

**Rewriting the producer through a bash heredoc violated `coordination#10` in the same session that cited it.** The fix was composed through a file and run by path, which is what the ruling says to do.

**The repo's ASCII gate caught literal arrows in my own substitution map**, and a stray CJK character in the taxonomy seed within a minute of writing it. The guard working on the guard.

## What is NOT here, and is named rather than implied

- **No unit test for `check_references.py`.** Its ability to fail is evidenced by the 33 findings before exclusions, not by a test. It uses a hardcoded `REPO_ROOT` and needs a seam first.
- **The identity stamp is half-built.** Source commit and generated-at need a release-time stamping step that does not exist.
- **`salience_tier` is unvalidated.** Blocked on `pdoom1` for the flavour-gate predicate.

Refs `pdoom-data#52`, `#65`, `#47`, `coordination#31`.
