### PR TITLE
docs: clear the ASCII backlog (pdoom-data#30) -- and the warning against clearing it was stale by eleven days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,10 +114,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 
 **Legend**:
-- 🎯 Major feature
-- ✨ Enhancement
-- 🐛 Bug fix
-- 📚 Documentation
-- 🔧 Configuration
-- ⚡ Performance
-- 🔒 Security
+- [TARGET] Major feature
+- [NEW] Enhancement
+- [BUG] Bug fix
+- [DOCS] Documentation
+- [TOOL] Configuration
+- [FAST] Performance
+- [LOCK] Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,14 +103,30 @@ have destroyed data. The repair and the de-arm landed together, and
 regains an unattended trigger. Re-arming is a deliberate act: remove the entry
 from `DISARMED` in the same commit that arms it.
 
-**Do not clear the ASCII backlog to make CI green.** About 20 files in `docs/`
-fail the gate on box-drawing and arrows. That failure is the only thing keeping
-the `documentation-publish` job from running, and that job appends to
-`DEVBLOG.md` with `echo >>` on every push to main, so the file grows without
-bound. Both are de-armed now, but the coupling is real. Also: never run
-`legacy/2025-09_prototype/fix_ascii.py`, whose `?` fallback would shred every
-tree diagram. Use an explicit substitution map that errors on unmapped
-characters.
+**The ASCII backlog is CLEARED, 2026-08-10, and the reason it was safe is the
+part worth keeping.** Nineteen files failed the gate on box-drawing, arrows and
+emoji. This paragraph used to say clearing them would arm `documentation-publish`,
+a job that appends to `DEVBLOG.md` with `echo >>` on every push to main so the
+file grows without bound.
+
+**That coupling was already dead when this warning was written and the warning
+outlived it.** The job was de-armed on 2026-07-30 by being **commented out** --
+`.github/workflows/documentation-ci.yml` lines 195-242, which is prose, not YAML.
+A commented job cannot run whether the gate above it is red or green, so the red
+was protecting nothing. **This is the stale-copy failure this file warns about
+two sections below, committed by this file, about itself.** Check the workflow
+before trusting a claim about the workflow.
+
+Still true and still load-bearing: **never run
+`legacy/2025-09_prototype/fix_ascii.py`**, whose `?` fallback would shred every
+tree diagram. The 2026-08-10 clearance used an explicit substitution map that
+**errors on unmapped characters**, keeps box-drawing at one ASCII character per
+box character so tree alignment survives, and hand-corrected the three Python
+files rather than substituting in them -- `check_evidence.py` carried en and em
+dashes **inside the string literals that normalise en and em dashes**, so a
+textual pass would have produced `replace("-", "-")` and silently disabled the
+check while turning the file green. That is the whole argument for an explicit
+map in one example.
 
 **Never open an existing file with `encoding="ascii"` for writing.** Python
 truncates on open, then raises on the first non-ASCII byte, destroying the file

--- a/REPO_NAVIGATION.md
+++ b/REPO_NAVIGATION.md
@@ -8,7 +8,7 @@ This is part of the P(Doom) project ecosystem consisting of three repositories:
 ### [DATA] [pdoom-data](https://github.com/PipFoweraker/pdoom-data)
 **AI Safety Data Lake & Timeline Events**
 - 1,194 timeline events (28 curated + 1,166 A-tier alignment research)
-- Three-zone data architecture (raw → transformed → serveable)
+- Three-zone data architecture (raw -> transformed -> serveable)
 - Automated data pipeline with validation
 - Interactive event browser tool
 - JSON exports for integration

--- a/data/raw/_templates/SOURCE_README.md
+++ b/data/raw/_templates/SOURCE_README.md
@@ -95,18 +95,18 @@ Get token from: [URL for getting token]
 
 ```
 [source_name]/
-├── README.md                   # This file
-├── extraction_script.py        # Main extraction script
-├── _templates/
-│   ├── _metadata.json         # Metadata template
-│   └── data_schema.json       # Schema definition
-└── dumps/
-    ├── [timestamp]/           # Timestamped dumps
-    │   ├── data.jsonl         # Extracted records (JSONL format)
-    │   └── _metadata.json     # Extraction metadata
-    └── [timestamp]/           # Subsequent dumps
-        ├── data.jsonl
-        └── _metadata.json
++-- README.md                   # This file
++-- extraction_script.py        # Main extraction script
++-- _templates/
+|   +-- _metadata.json         # Metadata template
+|   +-- data_schema.json       # Schema definition
++-- dumps/
+    +-- [timestamp]/           # Timestamped dumps
+    |   +-- data.jsonl         # Extracted records (JSONL format)
+    |   +-- _metadata.json     # Extraction metadata
+    +-- [timestamp]/           # Subsequent dumps
+        +-- data.jsonl
+        +-- _metadata.json
 ```
 
 ## Metadata Tracking
@@ -225,17 +225,17 @@ Solution: [Solution description]
 
 ```
 [Data Source]
-    ↓
+    v
 [extraction_script.py]
-    ↓
+    v
 data/raw/[source_name]/dumps/[timestamp]/data.jsonl
-    ↓
+    v
 [scripts/migration/migrate.py]
-    ↓
+    v
 data/transformed/validated/
-    ↓
+    v
 [Future: Cleaning & Enrichment]
-    ↓
+    v
 data/serveable/
 ```
 

--- a/data/raw/alignment_research/QUICK_START.md
+++ b/data/raw/alignment_research/QUICK_START.md
@@ -45,7 +45,7 @@ head -n 1 "${LATEST}data.jsonl" | python -m json.tool
 
 GitHub Actions runs automatically every Monday at 2am UTC.
 
-**Manual trigger**: Go to Actions tab → Weekly Data Refresh → Run workflow
+**Manual trigger**: Go to Actions tab -> Weekly Data Refresh -> Run workflow
 
 ## Files
 

--- a/data/raw/alignment_research/README.md
+++ b/data/raw/alignment_research/README.md
@@ -131,18 +131,18 @@ Get token from: https://huggingface.co/settings/tokens
 
 ```
 alignment_research/
-├── README.md                   # This file
-├── extraction_script.py        # Main extraction script
-├── _templates/
-│   ├── _metadata.json         # Metadata template
-│   └── data_schema.json       # Schema definition
-└── dumps/
-    ├── 2025-11-06_140000/     # Timestamped dumps
-    │   ├── data.jsonl         # Extracted records (JSONL format)
-    │   └── _metadata.json     # Extraction metadata
-    └── 2025-11-13_020000/     # Delta update
-        ├── data.jsonl
-        └── _metadata.json
++-- README.md                   # This file
++-- extraction_script.py        # Main extraction script
++-- _templates/
+|   +-- _metadata.json         # Metadata template
+|   +-- data_schema.json       # Schema definition
++-- dumps/
+    +-- 2025-11-06_140000/     # Timestamped dumps
+    |   +-- data.jsonl         # Extracted records (JSONL format)
+    |   +-- _metadata.json     # Extraction metadata
+    +-- 2025-11-13_020000/     # Delta update
+        +-- data.jsonl
+        +-- _metadata.json
 ```
 
 ## Metadata Tracking
@@ -268,17 +268,17 @@ Solution: Delta mode checks last_extraction_date. Use --force-full to re-extract
 
 ```
 Hugging Face API
-    ↓
+    v
 [extraction_script.py]
-    ↓
+    v
 data/raw/alignment_research/dumps/[timestamp]/data.jsonl
-    ↓
+    v
 [scripts/migration/migrate.py]
-    ↓
+    v
 data/transformed/validated/
-    ↓
+    v
 [Future: Cleaning & Enrichment]
-    ↓
+    v
 data/serveable/
 ```
 

--- a/data/serveable/README.md
+++ b/data/serveable/README.md
@@ -15,10 +15,10 @@
 
 This directory contains the final layer of the data lake architecture. Data here has been:
 
-1. ✅ Validated against schemas
-2. ✅ Cleaned and normalized
-3. ✅ Enriched with derived fields (where applicable)
-4. ✅ Optimized for consumption (indexed, formatted, compressed)
+1. [OK] Validated against schemas
+2. [OK] Cleaned and normalized
+3. [OK] Enriched with derived fields (where applicable)
+4. [OK] Optimized for consumption (indexed, formatted, compressed)
 
 **Current Status**: 1,194 timeline events ready for game integration
 
@@ -26,17 +26,17 @@ This directory contains the final layer of the data lake architecture. Data here
 
 ```
 serveable/
-├── MANIFEST.json           # Complete catalog of all serveable data
-├── api/                    # API-ready formats (JSON, REST-friendly)
-│   └── timeline_events/    # Game timeline events (1,194 events)
-│       ├── all_events.json           # Manual curated events (28)
-│       ├── by_year/                  # Manual events by year
-│       ├── by_category/              # Manual events by category
-│       ├── enriched_alignment_research/  # A-tier research events (1,166)
-│       │   ├── alignment_research_events.json
-│       │   └── by_year/              # Research events by year
-│       └── manifest.json             # Timeline events metadata
-└── analytics/              # Analytics-ready formats (future)
++-- MANIFEST.json           # Complete catalog of all serveable data
++-- api/                    # API-ready formats (JSON, REST-friendly)
+|   +-- timeline_events/    # Game timeline events (1,194 events)
+|       +-- all_events.json           # Manual curated events (28)
+|       +-- by_year/                  # Manual events by year
+|       +-- by_category/              # Manual events by category
+|       +-- enriched_alignment_research/  # A-tier research events (1,166)
+|       |   +-- alignment_research_events.json
+|       |   +-- by_year/              # Research events by year
+|       +-- manifest.json             # Timeline events metadata
++-- analytics/              # Analytics-ready formats (future)
 ```
 
 ## Data Sources
@@ -46,7 +46,7 @@ serveable/
 **Two datasets available:**
 
 #### 1. Manual Curated Events (28 events)
-**Source**: `data/raw/events/` → `scripts/transformation/clean_events.py`
+**Source**: `data/raw/events/` -> `scripts/transformation/clean_events.py`
 
 **Files**:
 - `all_events.json` - All 28 manual events
@@ -57,7 +57,7 @@ serveable/
 - `stats.json` - Statistics
 
 #### 2. Alignment Research Events (1,000 events)
-**Source**: `data/raw/alignment_research/` → cleaning → enrichment → transformation
+**Source**: `data/raw/alignment_research/` -> cleaning -> enrichment -> transformation
 
 **Files**:
 - `alignment_research/alignment_research_events.json` - All 1,000 events
@@ -86,11 +86,11 @@ with open('data/serveable/api/timeline_events/by_year/2024.json') as f:
 
 All data in the serveable zone:
 
-- ✅ Passes schema validation
-- ✅ Has complete attribution (sources, citations)
-- ✅ Is ASCII-compliant
-- ✅ Has proper metadata (version, timestamp)
-- ✅ Is idempotent (safe to regenerate)
+- [OK] Passes schema validation
+- [OK] Has complete attribution (sources, citations)
+- [OK] Is ASCII-compliant
+- [OK] Has proper metadata (version, timestamp)
+- [OK] Is idempotent (safe to regenerate)
 
 ### Freshness
 
@@ -152,13 +152,13 @@ print(f"  {len(events_2024)} events in 2024")
 ## Operations
 
 **Allowed**:
-- ✅ Read data
-- ✅ Regenerate from raw/transformed zones
-- ✅ Update via transformation pipelines
+- [OK] Read data
+- [OK] Regenerate from raw/transformed zones
+- [OK] Update via transformation pipelines
 
 **Not Allowed**:
-- ❌ Manual edits (always use pipelines)
-- ❌ Direct writes without validation
+- [NO] Manual edits (always use pipelines)
+- [NO] Direct writes without validation
 
 ## Related Documentation
 

--- a/docs/ALIGNMENT_RESEARCH_INTEGRATION.md
+++ b/docs/ALIGNMENT_RESEARCH_INTEGRATION.md
@@ -1,6 +1,6 @@
 # Alignment Research Dataset Integration Guide
 
-**Status**: ✅ Operational (as of 2025-11-06)
+**Status**: [OK] Operational (as of 2025-11-06)
 **Maintainer**: pdoom-data team
 **Data Source**: [StampyAI/alignment-research-dataset](https://huggingface.co/datasets/StampyAI/alignment-research-dataset)
 **License**: MIT
@@ -53,53 +53,53 @@ The Alignment Research Dataset integration provides automated, incremental inges
 ### Data Flow
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│  HuggingFace Dataset (StampyAI/alignment-research-dataset)  │
-│  - 12+ JSONL files (one per source)                         │
-│  - 10K-100K total records                                   │
-│  - Updated irregularly by community                         │
-└──────────────────────┬──────────────────────────────────────┘
-                       │
-                       │ HTTP Download
-                       │ (with caching)
-                       ▼
-┌─────────────────────────────────────────────────────────────┐
-│  Extraction Script (extraction_script.py)                   │
-│  - Streams JSONL files                                      │
-│  - Applies filters (date, source, keywords)                 │
-│  - Transforms to pdoom-data schema                          │
-│  - Adds provenance metadata                                 │
-│  - Detects deltas via timestamp comparison                  │
-└──────────────────────┬──────────────────────────────────────┘
-                       │
-                       │ Write JSONL + Metadata
-                       ▼
-┌─────────────────────────────────────────────────────────────┐
-│  RAW ZONE                                                   │
-│  data/raw/alignment_research/dumps/[timestamp]/             │
-│  ├── data.jsonl              (extracted records)            │
-│  └── _metadata.json          (extraction metadata)          │
-└──────────────────────┬──────────────────────────────────────┘
-                       │
-                       │ Schema Validation
-                       │ (validate_alignment_research.py)
-                       ▼
-┌─────────────────────────────────────────────────────────────┐
-│  TRANSFORMED ZONE (validated/)                              │
-│  data/transformed/validated/                                │
-│  - Schema-compliant records                                 │
-│  - Checksum verified                                        │
-│  - Ready for cleaning/enrichment                            │
-└──────────────────────┬──────────────────────────────────────┘
-                       │
-                       │ Future: Cleaning & Enrichment
-                       ▼
-┌─────────────────────────────────────────────────────────────┐
-│  SERVEABLE ZONE (analytics/, api/)                          │
-│  data/serveable/                                            │
-│  - Production-ready formats                                 │
-│  - Optimized for consumption                                │
-└─────────────────────────────────────────────────────────────┘
++-------------------------------------------------------------+
+|  HuggingFace Dataset (StampyAI/alignment-research-dataset)  |
+|  - 12+ JSONL files (one per source)                         |
+|  - 10K-100K total records                                   |
+|  - Updated irregularly by community                         |
++----------------------+--------------------------------------+
+                       |
+                       | HTTP Download
+                       | (with caching)
+                       v
++-------------------------------------------------------------+
+|  Extraction Script (extraction_script.py)                   |
+|  - Streams JSONL files                                      |
+|  - Applies filters (date, source, keywords)                 |
+|  - Transforms to pdoom-data schema                          |
+|  - Adds provenance metadata                                 |
+|  - Detects deltas via timestamp comparison                  |
++----------------------+--------------------------------------+
+                       |
+                       | Write JSONL + Metadata
+                       v
++-------------------------------------------------------------+
+|  RAW ZONE                                                   |
+|  data/raw/alignment_research/dumps/[timestamp]/             |
+|  +-- data.jsonl              (extracted records)            |
+|  +-- _metadata.json          (extraction metadata)          |
++----------------------+--------------------------------------+
+                       |
+                       | Schema Validation
+                       | (validate_alignment_research.py)
+                       v
++-------------------------------------------------------------+
+|  TRANSFORMED ZONE (validated/)                              |
+|  data/transformed/validated/                                |
+|  - Schema-compliant records                                 |
+|  - Checksum verified                                        |
+|  - Ready for cleaning/enrichment                            |
++----------------------+--------------------------------------+
+                       |
+                       | Future: Cleaning & Enrichment
+                       v
++-------------------------------------------------------------+
+|  SERVEABLE ZONE (analytics/, api/)                          |
+|  data/serveable/                                            |
+|  - Production-ready formats                                 |
+|  - Optimized for consumption                                |
++-------------------------------------------------------------+
 ```
 
 ### Component Architecture
@@ -127,7 +127,7 @@ The Alignment Research Dataset integration provides automated, incremental inges
 4. **GitHub Actions Workflow** (`.github/workflows/weekly-data-refresh.yml`)
    - Responsibility: Automated weekly data refresh
    - Trigger: Cron schedule (Monday 2am UTC) + manual dispatch
-   - Steps: Extract → Validate → Commit → Push
+   - Steps: Extract -> Validate -> Commit -> Push
    - Monitoring: Logs uploaded as artifacts (30-day retention)
 
 #### Supporting Infrastructure
@@ -168,18 +168,18 @@ The Alignment Research Dataset integration provides automated, incremental inges
 
 ```
 StampyAI/alignment-research-dataset/
-├── agentmodels.jsonl
-├── agisf.jsonl
-├── aisafety.info.jsonl
-├── alignmentforum.jsonl
-├── arbital.jsonl
-├── arxiv.jsonl
-├── blogs.jsonl
-├── distill.jsonl
-├── eaforum.jsonl
-├── lesswrong.jsonl
-├── special_docs.jsonl
-└── stampy.jsonl
++-- agentmodels.jsonl
++-- agisf.jsonl
++-- aisafety.info.jsonl
++-- alignmentforum.jsonl
++-- arbital.jsonl
++-- arxiv.jsonl
++-- blogs.jsonl
++-- distill.jsonl
++-- eaforum.jsonl
++-- lesswrong.jsonl
++-- special_docs.jsonl
++-- stampy.jsonl
 ```
 
 Each JSONL file contains records from a specific source, with consistent schema across all files.
@@ -315,7 +315,7 @@ python extraction_script.py --mode delta
 
 **Getting a Token**:
 1. Create account at https://huggingface.co
-2. Navigate to Settings → Access Tokens
+2. Navigate to Settings -> Access Tokens
 3. Create new token with "read" permissions
 4. Store as `HF_TOKEN` environment variable or GitHub secret
 
@@ -325,8 +325,8 @@ Each extraction creates a timestamped directory:
 
 ```
 data/raw/alignment_research/dumps/2025-11-06_104039/
-├── data.jsonl         # Extracted records (one per line)
-└── _metadata.json     # Extraction metadata
++-- data.jsonl         # Extracted records (one per line)
++-- _metadata.json     # Extraction metadata
 ```
 
 #### data.jsonl Format
@@ -659,7 +659,7 @@ pip install -r requirements.txt
 export HF_TOKEN="hf_your_token_here"
 
 # For GitHub Actions
-# Add as repository secret: Settings → Secrets → Actions → New secret
+# Add as repository secret: Settings -> Secrets -> Actions -> New secret
 # Name: HF_TOKEN
 # Value: your_token_here
 ```
@@ -971,4 +971,4 @@ rm -rf ~/.cache/huggingface/hub/datasets--StampyAI--alignment-research-dataset
 
 **Last Updated**: 2025-11-06
 **Document Version**: 1.0.0
-**Integration Status**: ✅ Production-ready
+**Integration Status**: [OK] Production-ready

--- a/docs/DATA_PUBLISHING_STRATEGY.md
+++ b/docs/DATA_PUBLISHING_STRATEGY.md
@@ -23,20 +23,20 @@ This document outlines the strategy for managing data visibility and public acce
 
 ```
 pdoom-data (private)
-├── data/raw/              [NEVER PUBLIC]
-│   ├── Source credentials, API tokens
-│   ├── Unvalidated data dumps
-│   └── Potentially sensitive metadata
-│
-├── data/transformed/      [NEVER PUBLIC]
-│   ├── Intermediate processing artifacts
-│   ├── Data quality logs
-│   └── Work-in-progress transformations
-│
-└── data/serveable/        [PUBLISHABLE]
-    ├── Fully validated datasets
-    ├── Complete attribution
-    └── Production-ready formats
++-- data/raw/              [NEVER PUBLIC]
+|   +-- Source credentials, API tokens
+|   +-- Unvalidated data dumps
+|   +-- Potentially sensitive metadata
+|
++-- data/transformed/      [NEVER PUBLIC]
+|   +-- Intermediate processing artifacts
+|   +-- Data quality logs
+|   +-- Work-in-progress transformations
+|
++-- data/serveable/        [PUBLISHABLE]
+    +-- Fully validated datasets
+    +-- Complete attribution
+    +-- Production-ready formats
 ```
 
 ### Publishing Strategy: GitHub Actions Automation (Recommended)
@@ -84,10 +84,10 @@ Never publish raw data repository
 ## Implementation Phases
 
 ### Phase 1: Current (No Publishing)
-- ✅ Establish three-zone architecture
-- ✅ Build extraction pipelines
-- ✅ Implement validation infrastructure
-- 🔄 Develop transformation scripts (Issues #13-16)
+- [OK] Establish three-zone architecture
+- [OK] Build extraction pipelines
+- [OK] Implement validation infrastructure
+- [SYNC] Develop transformation scripts (Issues #13-16)
 
 ### Phase 2: Serveable Zone Population (Future)
 - Transform raw data to serveable formats

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -172,22 +172,22 @@
 ## Documentation Status
 
 ### Complete & Current
-- ✅ Quick Start Integration
-- ✅ Integration Guide
-- ✅ Event Schema
-- ✅ Data Zones Architecture
-- ✅ Runbook
-- ✅ Cross-Repo Integration Issues
+- [OK] Quick Start Integration
+- [OK] Integration Guide
+- [OK] Event Schema
+- [OK] Data Zones Architecture
+- [OK] Runbook
+- [OK] Cross-Repo Integration Issues
 
 ### In Progress
-- 🔄 Public Communication Strategy
-- 🔄 Logs Consolidation Strategy
-- 🔄 DEVBLOG updates
+- [SYNC] Public Communication Strategy
+- [SYNC] Logs Consolidation Strategy
+- [SYNC] DEVBLOG updates
 
 ### Planned
-- 📋 API Documentation (once pdoom1-website implements)
-- 📋 Public Data Portal Documentation
-- 📋 Community Contribution Guide
+- [LIST] API Documentation (once pdoom1-website implements)
+- [LIST] Public Data Portal Documentation
+- [LIST] Community Contribution Guide
 
 ---
 

--- a/docs/EVENT_BROWSER_GUIDE.md
+++ b/docs/EVENT_BROWSER_GUIDE.md
@@ -248,17 +248,17 @@ You can add any custom metadata via the Custom Field JSON:
 
 ```
 Raw Events
-    ↓
+    v
 Cleaned Events (clean.py)
-    ↓
+    v
 Enriched Events (enrich.py)
-    ↓
+    v
 Timeline Events (transform_to_timeline_events.py)
-    ↓
+    v
 Serveable Zone
-    ↓
-[EVENT BROWSER] ← You are here
-    ↓
+    v
+[EVENT BROWSER] <- You are here
+    v
 Game Integration / Website Display
 ```
 
@@ -330,16 +330,16 @@ Integrate the Event Browser into the pdoom1-website to allow players to:
 
 ```
 Website Event Page
-    ↓
+    v
 [Event Browser Component] (embedded)
-    ↓
+    v
 Player Feedback Form
-    ↓
+    v
 Feedback API Endpoint (quarantined)
-    ↓
+    v
 Moderation Queue
-    ↓
-Approved Feedback → Metadata Updates
+    v
+Approved Feedback -> Metadata Updates
 ```
 
 ### Implementation Strategy
@@ -405,15 +405,15 @@ All player feedback is quarantined until review:
 
 ```
 data/
-└── feedback/
-    ├── pending/
-    │   └── feedback_12345.json
-    ├── approved/
-    │   └── feedback_12346.json
-    ├── rejected/
-    │   └── feedback_12347.json
-    └── metadata_updates/
-        └── events_metadata_community.json
++-- feedback/
+    +-- pending/
+    |   +-- feedback_12345.json
+    +-- approved/
+    |   +-- feedback_12346.json
+    +-- rejected/
+    |   +-- feedback_12347.json
+    +-- metadata_updates/
+        +-- events_metadata_community.json
 ```
 
 ### Moderation Interface
@@ -460,7 +460,7 @@ This layer can be:
 ### Keyboard Shortcuts
 
 - `Enter` in search box: Apply filters
-- `←/→` arrow keys: Navigate pages (future enhancement)
+- `<-/->` arrow keys: Navigate pages (future enhancement)
 - `Esc`: Clear selection (future enhancement)
 
 ### Bulk Operations

--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -14,12 +14,12 @@ This document describes the schema for game timeline events in the pdoom data ec
 
 ```
 data/raw/events/              (Landing Zone - Source of Truth)
-        ↓
+        v
 [Validation & Cleaning Pipeline]
-        ↓
+        v
 data/serveable/api/timeline_events/  (Serving Zone - Production Ready)
-        ↓
-pdoom1-website PostgreSQL → pdoom game → pdoom dashboard
+        v
+pdoom1-website PostgreSQL -> pdoom game -> pdoom dashboard
 ```
 
 ## Schema Definition
@@ -172,10 +172,10 @@ Each impact object has:
 
 Choose the most appropriate category:
 
-- Events primarily about research findings → `technical_research_breakthrough`
-- Events about funding problems → `funding_catastrophe`
-- Events about institutional failures → `institutional_decay`
-- Events about internal org crises → `organizational_crisis`
+- Events primarily about research findings -> `technical_research_breakthrough`
+- Events about funding problems -> `funding_catastrophe`
+- Events about institutional failures -> `institutional_decay`
+- Events about internal org crises -> `organizational_crisis`
 
 ### Rarity Guidelines
 
@@ -254,7 +254,7 @@ The cleaning pipeline generates multiple output formats in `data/serveable/api/t
 ### 4. Event Index
 - **File**: `event_index.json`
 - **Use**: Lightweight lookup, autocomplete
-- **Format**: Event ID → {title, year, category, rarity}
+- **Format**: Event ID -> {title, year, category, rarity}
 
 ### 5. Manifest
 - **File**: `manifest.json`

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1,4 +1,4 @@
-# Integration Guide: pdoom-data → pdoom1 Game
+# Integration Guide: pdoom-data -> pdoom1 Game
 
 **Version**: 1.0.0
 **Last Updated**: 2025-11-09
@@ -13,19 +13,19 @@ This guide explains how to integrate data from pdoom-data into the pdoom1 game, 
 
 ```
 pdoom-data (this repo)
-    ├── data/raw/                    # Source of truth (never modified)
-    ├── data/transformed/            # Processed data (cleaned, enriched)
-    └── data/serveable/              # Production-ready, optimized
-            ↓
+    +-- data/raw/                    # Source of truth (never modified)
+    +-- data/transformed/            # Processed data (cleaned, enriched)
+    +-- data/serveable/              # Production-ready, optimized
+            v
     [Database Import or Direct Sync]
-            ↓
+            v
 pdoom1-website
-    └── PostgreSQL events table
-            ↓
+    +-- PostgreSQL events table
+            v
     [REST API: GET /api/events]
-            ↓
-        ┌───────┴───────┐
-        ↓               ↓
+            v
+        +-------+-------+
+        v               v
     pdoom (game)    pdoom-dashboard
 ```
 

--- a/docs/PUBLIC_COMMUNICATION_STRATEGY.md
+++ b/docs/PUBLIC_COMMUNICATION_STRATEGY.md
@@ -81,21 +81,21 @@ This document outlines the strategy for:
 
 ```
 logs/
-├── consolidated/               # NEW: Human-readable summaries
-│   └── YYYY-MM-DD_summary.md  # Daily summary of all operations
-├── pipeline/                   # Pipeline execution logs
-│   └── YYYY-MM-DD_HH-MM-SS/
-│       ├── validation.log
-│       ├── cleaning.log
-│       ├── enrichment.log
-│       ├── transformation.log
-│       └── manifest.log
-├── extraction/                 # Source data extraction
-│   └── alignment_research/
-│       └── YYYY-MM-DD.log
-└── validation/                 # Schema validation
-    └── alignment_research/
-        └── YYYY-MM-DD.log
++-- consolidated/               # NEW: Human-readable summaries
+|   +-- YYYY-MM-DD_summary.md  # Daily summary of all operations
++-- pipeline/                   # Pipeline execution logs
+|   +-- YYYY-MM-DD_HH-MM-SS/
+|       +-- validation.log
+|       +-- cleaning.log
+|       +-- enrichment.log
+|       +-- transformation.log
+|       +-- manifest.log
++-- extraction/                 # Source data extraction
+|   +-- alignment_research/
+|       +-- YYYY-MM-DD.log
++-- validation/                 # Schema validation
+    +-- alignment_research/
+        +-- YYYY-MM-DD.log
 ```
 
 **Consolidation Script**: `scripts/logging/consolidate_logs.py`
@@ -433,19 +433,19 @@ jobs:
 ## Privacy & Security Considerations
 
 ### What to Share Publicly
-✅ Data quality metrics
-✅ Record counts and statistics
-✅ Schema versions
-✅ Pipeline execution times
-✅ Error rates (aggregate)
-✅ Dataset descriptions
+[OK] Data quality metrics
+[OK] Record counts and statistics
+[OK] Schema versions
+[OK] Pipeline execution times
+[OK] Error rates (aggregate)
+[OK] Dataset descriptions
 
 ### What to Keep Private
-❌ API keys and credentials
-❌ Internal infrastructure details
-❌ Specific error messages with paths
-❌ Performance bottlenecks (until fixed)
-❌ Unreleased features in development
+[NO] API keys and credentials
+[NO] Internal infrastructure details
+[NO] Specific error messages with paths
+[NO] Performance bottlenecks (until fixed)
+[NO] Unreleased features in development
 
 ---
 
@@ -533,4 +533,4 @@ jobs:
 
 ---
 
-**Status**: ✅ Strategy documented, 🔄 Implementation in progress
+**Status**: [OK] Strategy documented, [SYNC] Implementation in progress

--- a/docs/QUICK_START_INTEGRATION.md
+++ b/docs/QUICK_START_INTEGRATION.md
@@ -432,9 +432,9 @@ All repositories automatically stay in sync with pdoom-data:
 
 ### After Integration
 
-- **pdoom1-website**: PostgreSQL `events` table → API at `GET /api/events`
-- **pdoom game**: `res://data/events/` → Loaded via `EventLoader.gd`
-- **pdoom-dashboard**: Fetches from API → Displays in React components
+- **pdoom1-website**: PostgreSQL `events` table -> API at `GET /api/events`
+- **pdoom game**: `res://data/events/` -> Loaded via `EventLoader.gd`
+- **pdoom-dashboard**: Fetches from API -> Displays in React components
 
 ---
 

--- a/docs/sessions/SESSION_2025-11-06_ALIGNMENT_RESEARCH_INTEGRATION.md
+++ b/docs/sessions/SESSION_2025-11-06_ALIGNMENT_RESEARCH_INTEGRATION.md
@@ -3,7 +3,7 @@
 **Date**: 2025-11-06
 **Session Type**: Data Source Integration
 **Duration**: ~3 hours implementation + documentation
-**Status**: ✅ **COMPLETE** - Production Ready
+**Status**: [OK] **COMPLETE** - Production Ready
 
 ---
 
@@ -13,11 +13,11 @@ Successfully integrated the StampyAI Alignment Research Dataset into pdoom-data'
 
 ### Key Achievements
 
-✅ **Complete End-to-End Pipeline** - Raw ingestion → validation → weekly automation
-✅ **1000 Records Extracted** - 27MB of alignment research data (100% validation pass rate)
-✅ **Zero Errors** - Flawless execution in testing and production runs
-✅ **Comprehensive Documentation** - 60+ pages of guides, templates, and runbooks
-✅ **Future-Proof Templates** - Reusable patterns for adding more data sources
+[OK] **Complete End-to-End Pipeline** - Raw ingestion -> validation -> weekly automation
+[OK] **1000 Records Extracted** - 27MB of alignment research data (100% validation pass rate)
+[OK] **Zero Errors** - Flawless execution in testing and production runs
+[OK] **Comprehensive Documentation** - 60+ pages of guides, templates, and runbooks
+[OK] **Future-Proof Templates** - Reusable patterns for adding more data sources
 
 ---
 
@@ -28,13 +28,13 @@ Successfully integrated the StampyAI Alignment Research Dataset into pdoom-data'
 #### Directory Structure
 ```
 data/raw/alignment_research/
-├── README.md (7KB)                    # Source documentation
-├── extraction_script.py (21KB)        # Main extraction tool
-├── _templates/
-│   └── _metadata.json (2KB)          # Metadata template
-└── dumps/
-    ├── 2025-11-06_103900/ (2.2MB)    # Test extraction (100 records)
-    └── 2025-11-06_104039/ (27MB)     # Initial dataset (1000 records)
++-- README.md (7KB)                    # Source documentation
++-- extraction_script.py (21KB)        # Main extraction tool
++-- _templates/
+|   +-- _metadata.json (2KB)          # Metadata template
++-- dumps/
+    +-- 2025-11-06_103900/ (2.2MB)    # Test extraction (100 records)
+    +-- 2025-11-06_104039/ (27MB)     # Initial dataset (1000 records)
 ```
 
 #### Configuration Files
@@ -132,7 +132,7 @@ data/raw/alignment_research/
 
 5. **Data Quality**
    - SHA-256 checksums for verification
-   - Atomic file operations (temp → rename)
+   - Atomic file operations (temp -> rename)
    - Complete provenance tracking
    - Attribution and licensing metadata
 
@@ -204,11 +204,11 @@ data/raw/alignment_research/
 
 | Metric | Value | Status |
 |--------|-------|--------|
-| **Schema Compliance** | 100% | ✅ Pass |
-| **Required Fields** | 100% complete | ✅ Pass |
-| **Duplicate IDs** | 0 | ✅ Pass |
-| **Checksum Verification** | 100% match | ✅ Pass |
-| **Metadata Completeness** | 100% | ✅ Pass |
+| **Schema Compliance** | 100% | [OK] Pass |
+| **Required Fields** | 100% complete | [OK] Pass |
+| **Duplicate IDs** | 0 | [OK] Pass |
+| **Checksum Verification** | 100% match | [OK] Pass |
+| **Metadata Completeness** | 100% | [OK] Pass |
 
 ### Sample Record
 
@@ -653,7 +653,7 @@ head -n 1 data/raw/alignment_research/dumps/[timestamp]/data.jsonl | python -m j
 **Lines of Code Written**: ~1,800
 **Documentation Pages**: ~60
 **Data Extracted**: 1,000 records (27MB)
-**Status**: ✅ **PRODUCTION READY**
+**Status**: [OK] **PRODUCTION READY**
 
 ---
 

--- a/docs/sessions/SESSION_2025-11-24_EVENT_BROWSER_AND_FEEDBACK.md
+++ b/docs/sessions/SESSION_2025-11-24_EVENT_BROWSER_AND_FEEDBACK.md
@@ -114,17 +114,17 @@ Built an interactive browser-based event management tool and designed a comprehe
 **Architecture**:
 ```
 Website Event Page
-    ↓
+    v
 [Embedded Event Browser]
-    ↓
+    v
 Player Feedback Form
-    ↓
+    v
 POST /api/events/feedback (Quarantined)
-    ↓
+    v
 Admin Moderation Panel
-    ↓
+    v
 Community Metadata Layer
-    ↓
+    v
 Display on Website + Export to pdoom-data
 ```
 

--- a/scripts/transformation/clean.py
+++ b/scripts/transformation/clean.py
@@ -3,7 +3,7 @@
 Generalized data cleaning pipeline for the transformed zone.
 
 This script implements the cleaning layer of the data lake:
-    data/raw/* → data/transformed/validated/* → data/transformed/cleaned/*
+    data/raw/* -> data/transformed/validated/* -> data/transformed/cleaned/*
 
 Operations:
 - Deduplication (by ID, by content similarity)
@@ -164,9 +164,9 @@ class DataCleaner:
         """
         Convert non-ASCII characters to ASCII equivalents.
 
-        Smart quotes → straight quotes
-        Em/en dashes → hyphens
-        Accented characters → base characters
+        Smart quotes -> straight quotes
+        Em/en dashes -> hyphens
+        Accented characters -> base characters
 
         Args:
             text: Text potentially containing non-ASCII
@@ -195,7 +195,7 @@ class DataCleaner:
         for old, new in replacements.items():
             text = text.replace(old, new)
 
-        # Decompose accented characters (é → e)
+        # Decompose accented characters (e-acute -> e)
         # NFKD = Compatibility Decomposition
         text = unicodedata.normalize('NFKD', text)
 

--- a/scripts/transformation/enrich.py
+++ b/scripts/transformation/enrich.py
@@ -3,7 +3,7 @@
 Generalized data enrichment pipeline for the transformed zone.
 
 This script implements the enrichment layer of the data lake:
-    data/transformed/cleaned/* → data/transformed/enriched/*
+    data/transformed/cleaned/* -> data/transformed/enriched/*
 
 Operations:
 - Extract temporal fields (year, quarter, month, decade)

--- a/scripts/validation/check_all.py
+++ b/scripts/validation/check_all.py
@@ -127,12 +127,6 @@ def main():
         print("FAILED: %d gating check(s) -- %s" % (len(failures), ", ".join(failures)))
         return 1
     print("All gating checks pass.")
-    print()
-    print("Note: 'Development Documentation CI/CD' is red in GitHub Actions and is")
-    print("expected to be. It fails an ASCII gate on about 19 documentation files,")
-    print("and that failure is currently the only thing preventing a job that")
-    print("appends to DEVBLOG.md on every push to main. See CLAUDE.md before")
-    print("clearing it.")
     return 0
 
 

--- a/scripts/validation/check_evidence.py
+++ b/scripts/validation/check_evidence.py
@@ -67,7 +67,7 @@ def normalise(text):
     content.
     """
     t = text.lower()
-    t = t.replace("–", "-").replace("—", "-")
+    t = t.replace(u"\u2013", "-").replace(u"\u2014", "-")  # en dash, em dash
     t = re.sub(r"[,;:()\[\]{}\"'`]", " ", t)
     t = re.sub(r"\s+", " ", t)
     return t


### PR DESCRIPTION
docs: clear the ASCII backlog, and correct the warning that said not to

Closes pdoom-data#30. Nineteen files, 1,175 substitutions, and the interesting
part is why this was safe.

CLAUDE.md said clearing the backlog would arm documentation-publish, a job that
appends to DEVBLOG.md with `echo >>` on every push to main so the file grows
without bound. That coupling was already dead. The job was de-armed on
2026-07-30 by being commented out -- documentation-ci.yml lines 195-242 are
prose, not YAML -- and a commented job cannot run whether the gate above it is
red or green. The warning outlived the thing it warned about by eleven days,
which is the stale-copy failure CLAUDE.md itself describes two sections further
down. Corrected there rather than deleted, because the reasoning is still how
you check the next one.

How the substitution was done, since the wrong method here is destructive:

An explicit map that ERRORS on unmapped characters, never the '?' fallback that
legacy/2025-09_prototype/fix_ascii.py would apply. All nine box-drawing
characters map to exactly one ASCII character, so tree diagrams keep their
alignment rather than collapsing. 27 distinct characters appeared; each was
surveyed and mapped deliberately, and emoji became bracketed words ([OK], [NO],
[SYNC]) rather than being dropped.

The three Python files were hand-corrected, NOT substituted, and one of them is
the argument for the whole approach: check_evidence.py carried en and em dashes
INSIDE the string literals that normalise en and em dashes. A textual pass
would have produced replace("-", "-"), silently disabling the normalisation
while turning the file green. It is now written as – and — escapes,
and normalise() is exercised to prove the behaviour is unchanged. clean.py's
e-acute was an illustration of what its own code does, so it reads "e-acute ->
e" rather than "e -> e", which would have been a comment that says nothing.

check_all.py's trailing note explaining the expected red is removed, because it
is no longer true and a note that outlives its fact is how this started.

Verified: validate_ascii.py clean across 227 files; all ten gating checks pass;
three rebuild checks byte-identical.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
