### PR TITLE
fix: the three timeline_events sidecars claimed 28 of 1,194 for nine months (pdoom-data#52) -- and the allowlist that let them

### DIFF
--- a/config/reference_drift.json
+++ b/config/reference_drift.json
@@ -124,6 +124,12 @@
       "reference": "logs/migration/migration.json",
       "reason": "RUNTIME. Written by the migration script when it runs; absent in a clean checkout, which is correct.",
       "accepted_on": "2026-08-06"
+    },
+    {
+      "path": "docs/CORPUS_PROPOSAL_2026-08-09.md",
+      "reference": "data/raw/alignment_research/dumps/2025-12-24_063313/data.jsonl",
+      "reason": "UNTRACKED BY DESIGN. The 196MB arXiv dump is matched by .gitignore:24 (data/raw/alignment_research/dumps/*/data.jsonl), so it exists on this workstation and in no clean checkout. The proposal cites it because it is the evidence for the corpus measurements, and the citation is honest -- but a reader in a fresh clone cannot fetch it, which is exactly what this checker is for. Worth knowing: this is also why the 892 email addresses in that dump were never published, while the 306 in data/transformed/ were (pdoom-data#71). Tracked by pdoom-data#58, which asks what the corpus should be.",
+      "accepted_on": "2026-08-10"
     }
   ]
 }

--- a/data/serveable/api/timeline_events/event_index.json
+++ b/data/serveable/api/timeline_events/event_index.json
@@ -1,46 +1,4 @@
 {
-  "ftx_future_fund_collapse_2022": {
-    "title": "FTX Future Fund Collapse",
-    "year": 2022,
-    "category": "funding_catastrophe",
-    "rarity": "rare"
-  },
-  "cais_ftx_clawback_2023": {
-    "title": "Center for AI Safety FTX Clawback",
-    "year": 2023,
-    "category": "funding_catastrophe",
-    "rarity": "common"
-  },
-  "crypto_funding_crash_2022": {
-    "title": "Crypto Market AI Funding Crash",
-    "year": 2022,
-    "category": "funding_catastrophe",
-    "rarity": "common"
-  },
-  "ltff_funding_gap_2023": {
-    "title": "Long-Term Future Fund Funding Gap",
-    "year": 2023,
-    "category": "funding_catastrophe",
-    "rarity": "common"
-  },
-  "ea_funding_concentration_risk_2023": {
-    "title": "EA Funding Concentration Crisis",
-    "year": 2023,
-    "category": "funding_catastrophe",
-    "rarity": "common"
-  },
-  "grant_application_backlog_2024": {
-    "title": "Grant Application Backlog Crisis",
-    "year": 2024,
-    "category": "funding_catastrophe",
-    "rarity": "common"
-  },
-  "venture_capital_ai_safety_drought_2024": {
-    "title": "Venture Capital AI Safety Drought",
-    "year": 2024,
-    "category": "funding_catastrophe",
-    "rarity": "common"
-  },
   "openai_board_crisis_2023": {
     "title": "OpenAI Board Crisis and CEO Firing",
     "year": 2023,
@@ -125,14 +83,56 @@
     "category": "technical_research_breakthrough",
     "rarity": "rare"
   },
+  "ftx_future_fund_collapse_2022": {
+    "title": "FTX Future Fund Collapse",
+    "year": 2022,
+    "category": "funding_catastrophe",
+    "rarity": "rare"
+  },
+  "cais_ftx_clawback_2023": {
+    "title": "Center for AI Safety FTX Clawback",
+    "year": 2023,
+    "category": "funding_catastrophe",
+    "rarity": "common"
+  },
+  "crypto_funding_crash_2022": {
+    "title": "Crypto Market AI Funding Crash",
+    "year": 2022,
+    "category": "funding_catastrophe",
+    "rarity": "common"
+  },
+  "ltff_funding_gap_2023": {
+    "title": "Long-Term Future Fund Funding Gap",
+    "year": 2023,
+    "category": "funding_catastrophe",
+    "rarity": "common"
+  },
+  "ea_funding_concentration_risk_2023": {
+    "title": "EA Funding Concentration Crisis",
+    "year": 2023,
+    "category": "funding_catastrophe",
+    "rarity": "common"
+  },
+  "grant_application_backlog_2024": {
+    "title": "Grant Application Backlog Crisis",
+    "year": 2024,
+    "category": "funding_catastrophe",
+    "rarity": "common"
+  },
+  "venture_capital_ai_safety_drought_2024": {
+    "title": "Venture Capital AI Safety Drought",
+    "year": 2024,
+    "category": "funding_catastrophe",
+    "rarity": "common"
+  },
   "uk_ai_safety_to_security_2025": {
-    "title": "UK AI Safety Institute \u2192 AI Security Institute",
+    "title": "UK AI Safety Institute -> AI Security Institute",
     "year": 2025,
     "category": "institutional_decay",
     "rarity": "common"
   },
   "us_aisi_to_caisi_2025": {
-    "title": "US AISI \u2192 Center for AI Standards and Innovation",
+    "title": "US AISI -> Center for AI Standards and Innovation",
     "year": 2025,
     "category": "institutional_decay",
     "rarity": "common"
@@ -166,5 +166,7001 @@
     "year": 2025,
     "category": "institutional_decay",
     "rarity": "rare"
+  },
+  "arxiv_4a1054779386836e": {
+    "title": "Energetics of the brain and AI",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2a9728dfa4edd6fd": {
+    "title": "Parametric Bounded L?b's Theorem and Robust Cooperation of Bounded Agents",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2831a92843a5e489": {
+    "title": "\"Why Should I Trust You?\": Explaining the Predictions of Any Classifier",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4f40d85a64ad6794": {
+    "title": "Limits to Verification and Validation of Agentic Behavior",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_867cf2251f9d3258": {
+    "title": "Self-Modification of Policy and Utility Function in Rational Agents",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2ad044ccbe86ca04": {
+    "title": "Avoiding Wireheading with Value Reinforcement Learning",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6192ac5138b95d9b": {
+    "title": "Concrete Problems in AI Safety",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d2248d916a22dd16": {
+    "title": "Mammalian Value Systems",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_713254917f596bcc": {
+    "title": "Logical Induction",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_557bfceacbe79950": {
+    "title": "Google's Neural Machine Translation System: Bridging the Gap between Human and Machine Translation",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_839abeea475aefba": {
+    "title": "Artificial Intelligence Safety and Cybersecurity: a Timeline of AI Failures",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bf605e3eb967ec30": {
+    "title": "Neural Architecture Search with Reinforcement Learning",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a69c2e9998290359": {
+    "title": "Simple and Scalable Predictive Uncertainty Estimation using Deep Ensembles",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_42706567777fd6de": {
+    "title": "Toward negotiable reinforcement learning: shifting priorities in Pareto optimal sequential decision-making",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_26679affba27c265": {
+    "title": "Enabling Robots to Communicate their Objectives",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_68b377556f438319": {
+    "title": "Right for the Right Reasons: Training Differentiable Models by Constraining their Explanations",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3d2e35721e7e6af2": {
+    "title": "Dynamic Safe Interruptibility for Decentralized Multi-Agent Reinforcement Learning",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e0208f404de76bd7": {
+    "title": "That is not dead which can eternal lie: the aestivation hypothesis for resolving Fermi's paradox",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_dc62ec723cf1430d": {
+    "title": "Robot Planning with Mathematical Models of Human State and Action",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_56382c60c6c3e7b0": {
+    "title": "Reinforcement Learning with a Corrupted Reward Channel",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_85d693126567d483": {
+    "title": "When Will AI Exceed Human Performance? Evidence from AI Experts",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9888ab8acacc8f4a": {
+    "title": "Universal Reinforcement Learning Algorithms: Survey and Experiments",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3bc060c075113a3a": {
+    "title": "Low Impact Artificial Intelligences",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ac6144846c25f722": {
+    "title": "Deep reinforcement learning from human preferences",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_abbee081bc544819": {
+    "title": "Trial without Error: Towards Safe Reinforcement Learning via Human Intervention",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d83deddb25098692": {
+    "title": "Pragmatic-Pedagogic Value Alignment",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_f0e7df67a2fa5a45": {
+    "title": "Guidelines for Artificial Intelligence Containment",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5bba428001708f8d": {
+    "title": "A Formal Approach to the Problem of Logical Non-Omniscience",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_259e8b768252584d": {
+    "title": "DropoutDAgger: A Bayesian Approach to Safe Imitation Learning",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1781dfeed21085a6": {
+    "title": "Incorrigibility in the CIRL Framework",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b61d7e33ba6251a4": {
+    "title": "Servant of Many Masters: Shifting priorities in Pareto-optimal sequential decision-making",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7e5e07b1807afa4e": {
+    "title": "Good and safe uses of AI Oracles",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cab1fd1544e648fd": {
+    "title": "Leave no Trace: Learning to Reset for Safe and Autonomous Reinforcement Learning",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9c5d157ee6114e5f": {
+    "title": "AI Safety Gridworlds",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0de42c1e48b1ed52": {
+    "title": "A Low-Cost Ethics Shaping Approach for Designing Reinforcement Learning Agents",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bae9f6db20a311d3": {
+    "title": "AI Safety and Reproducibility: Establishing Robust Foundations for the Neuropsychology of Human Values",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_901b2797a974e580": {
+    "title": "Occam's razor is insufficient to infer the preferences of irrational agents",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_caf3b68cdb135855": {
+    "title": "Indifference' methods for managing agent rewards",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_580086687492613b": {
+    "title": "Safe Exploration in Continuous Action Spaces",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cb0bea2dbf3f6dba": {
+    "title": "Learning from Richer Human Guidance: Augmenting Comparison-Based Learning with Feature Queries",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1f79ae6b4d4c0df3": {
+    "title": "Goal Inference Improves Objective and Perceived Performance in Human-Robot Collaboration",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8a86edf03dc7b48a": {
+    "title": "More Robust Doubly Robust Off-policy Evaluation",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ae99d6d74bc1c08e": {
+    "title": "The Malicious Use of Artificial Intelligence: Forecasting, Prevention, and Mitigation",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9e9525f3735aa4c6": {
+    "title": "Machine Theory of Mind",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c5e91218315409dd": {
+    "title": "The Surprising Creativity of Digital Evolution: A Collection of Anecdotes from the Evolutionary Computation and Artificial Life Research Communities",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0ef3ae9d9df8bf40": {
+    "title": "Categorizing Variants of Goodhart's Law",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b6b762b2e10ccbe9": {
+    "title": "Deep k-Nearest Neighbors: Towards Confident, Interpretable and Robust Deep Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_45ed72f40204d0db": {
+    "title": "Fractal AI: A fragile theory of intelligence",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_24008e5ce4a89c6c": {
+    "title": "Neural Network Quine",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bb3ed7bc24be17f9": {
+    "title": "Adversarial Logit Pairing",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_21267b4187d0fc7e": {
+    "title": "Learning-based Model Predictive Control for Safe Exploration",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2030b02686788da3": {
+    "title": "Computational Power and the Social Impact of Artificial Intelligence",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_522f7a056dc115d3": {
+    "title": "Fortified Networks: Improving the Robustness of Deep Networks by Modeling the Manifold of Hidden Representations",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a2c958c9052a7d8d": {
+    "title": "Large scale distributed neural network training through online distillation",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_043fe6dc0beaa8b2": {
+    "title": "Emergent Communication through Negotiation",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_62f122481baeefc3": {
+    "title": "Adversarial Attacks Against Medical Deep Learning Systems",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_30f1a7a1789ef924": {
+    "title": "Zero-Shot Visual Imitation",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_721ce41554be015d": {
+    "title": "Realistic Evaluation of Deep Semi-Supervised Learning Algorithms",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_acd42e38d07345ab": {
+    "title": "The Best of Both Worlds: Combining Recent Advances in Neural Machine Translation",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e20fd9f7d083bd38": {
+    "title": "AI safety via debate",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f941eca7326ad9c4": {
+    "title": "The Blessings of Multiple Causes",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c5fc3042c65ffa89": {
+    "title": "Unsupervised Learning of Neural Networks to Explain Neural Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_779a2317c0abb602": {
+    "title": "Constrained Policy Improvement for Safe and Efficient Reinforcement Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9c912055d2d387ee": {
+    "title": "A Framework and Method for Online Inverse Reinforcement Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c92e4d9890809f73": {
+    "title": "Learning Safe Policies with Expert Guidance",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_59bdc581d12f5d74": {
+    "title": "Maximum Causal Tsallis Entropy Imitation Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f9427d97b1de83b7": {
+    "title": "Training verified learners with learned verifiers",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_408fdf74dfa3936a": {
+    "title": "Playing hard exploration games by watching YouTube",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_44db885f14f4567f": {
+    "title": "Explaining Explanations: An Overview of Interpretability of Machine Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_02d29384d4f1acc9": {
+    "title": "Probabilistically Safe Robot Planning with Confidence-Based Human Predictions",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_870cfbdf19d603ef": {
+    "title": "Between Progress and Potential Impact of AI: the Neglected Dimensions",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a8daf511a90c10f6": {
+    "title": "Sufficient Conditions for Idealised Models to Have No Adversarial Examples: a Theoretical and Empirical Study with Bayesian Neural Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_71e4b5b262c8176a": {
+    "title": "An Efficient, Generalized Bellman Update For Cooperative Inverse Reinforcement Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f7b6498293e5e00f": {
+    "title": "Adaptive Mechanism Design: Learning to Promote Cooperation",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b7eb706ddf3fc687": {
+    "title": "Scrutinizing and De-Biasing Intuitive Physics with Neural Stethoscopes",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6c1540dbd5a19818": {
+    "title": "Evolving simple programs for playing Atari games",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d50b5ef4912f0d1a": {
+    "title": "A Survey of Inverse Reinforcement Learning: Challenges, Methods and Progress",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_137bbec0e331870d": {
+    "title": "RUDDER: Return Decomposition for Delayed Rewards",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_60ce6df24e15aa3f": {
+    "title": "Resource-Efficient Neural Architect",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0a524cefae2d9470": {
+    "title": "Interpretable Discovery in Large Image Data Sets",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_18f8987e4b8187c6": {
+    "title": "Human-Interactive Subgoal Supervision for Efficient Inverse Reinforcement Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e58ee43c60372af1": {
+    "title": "On Adversarial Examples for Character-Level Neural Machine Translation",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_52818dc9c9b0ec8f": {
+    "title": "Multi-agent Inverse Reinforcement Learning for Certain General-sum Stochastic Games",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0e3cde25cfb8379f": {
+    "title": "Adversarial Active Exploration for Inverse Dynamics Model Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_66b16ddb540dbf79": {
+    "title": "Towards Mixed Optimization for Reinforcement Learning with Program Synthesis",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_ad7cc0e44a27d325": {
+    "title": "Ranked Reward: Enabling Self-Play Reinforcement Learning for Combinatorial Optimization",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_13c24361877d0d2f": {
+    "title": "A Game-Based Approximate Verification of Deep Neural Networks with Provable Guarantees",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f9434e9f3ee20787": {
+    "title": "Universal Transformers",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f2582a779889fe2c": {
+    "title": "Safe Reinforcement Learning via Probabilistic Shields",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d3a402637ed5f7a2": {
+    "title": "Interpretable Latent Spaces for Learning from Demonstration",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8d97dd0f7dbc55a0": {
+    "title": "Safe Option-Critic: Learning Safety in the Option-Critic Architecture",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3b8e895af2010f42": {
+    "title": "EnsembleDAgger: A Bayesian Approach to Safe Imitation Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_92a5e7db3083500c": {
+    "title": "Evaluating and Understanding the Robustness of Adversarial Logit Pairing",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c66e65c42875adef": {
+    "title": "Variational Option Discovery Algorithms",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0d235ae393c51863": {
+    "title": "Security and Privacy Issues in Deep Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_71ea3916b563f9c4": {
+    "title": "Generalization Error in Deep Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5cc4fc269b34b5b6": {
+    "title": "Building Safer AGI by introducing Artificial Stupidity",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f1216e608f8dd839": {
+    "title": "Directed Policy Gradient for Safe Reinforcement Learning with Human Advice",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_319dc219983bf377": {
+    "title": "Analyzing Inverse Problems with Invertible Neural Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c50214c8f80f3b40": {
+    "title": "The Social Cost of Strategic Classification",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ffbaa6c6637a57a2": {
+    "title": "Why Self-Attention? A Targeted Evaluation of Neural Machine Translation Architectures",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1413c089690f9c70": {
+    "title": "A Roadmap for Robust End-to-End Alignment",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_68473420afe61cd8": {
+    "title": "Reinforcement Learning under Threats",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_07f0f2a80bb55b2d": {
+    "title": "Learning Invariances for Policy Generalization",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_4d58fc236181a582": {
+    "title": "Discriminator-Actor-Critic: Addressing Sample Inefficiency and Reward Bias in Adversarial Imitation Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2d7d2d0004b78667": {
+    "title": "Expert-augmented actor-critic for ViZDoom and Montezumas Revenge",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2be3bbe1029a6ad6": {
+    "title": "Abstraction Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ec316c9e111cb696": {
+    "title": "CM3: Cooperative Multi-goal Multi-stage Multi-agent Reinforcement Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_999fd36ceabc972b": {
+    "title": "Towards Better Interpretability in Deep Q-Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_100ba189bf0dc01a": {
+    "title": "Interpretable Reinforcement Learning with Ensemble Methods",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_dd92a06770fa00e4": {
+    "title": "Playing the Game of Universal Adversarial Perturbations",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_21fe8264295b133a": {
+    "title": "Interpretable Multi-Objective Reinforcement Learning through Policy Orchestration",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6a8d9093f9310ee6": {
+    "title": "Stakeholders in Explainable AI",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_92555068989b194c": {
+    "title": "SmartChoices: Hybridizing Programming and Machine Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b750fa887406a883": {
+    "title": "Training Machine Learning Models by Regularizing their Explanations",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b1131d9d90cd5099": {
+    "title": "Bayesian Policy Optimization for Model Uncertainty",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2bc37a9bb4a99905": {
+    "title": "Reinforcement Learning with Perturbed Rewards",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2cddd5559522d630": {
+    "title": "Unsupervised Learning via Meta-Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_aa96e047b272d327": {
+    "title": "Sanity Checks for Saliency Maps",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ba8057b3b54d04c0": {
+    "title": "Fast Context Adaptation via Meta-Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c8093ac4da9fd19b": {
+    "title": "The 30-Year Cycle In The AI Debate",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_301c7ed4b11f8ec0": {
+    "title": "Batch Active Preference-Based Learning of Reward Functions",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2e2b27a6cd1a3469": {
+    "title": "Secure Deep Learning Engineering: A Software Quality Assurance Perspective",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2cca17ac0cccda95": {
+    "title": "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_03dacb5f6ba0911a": {
+    "title": "Deep Imitative Models for Flexible Inference, Planning, and Control",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_235d4287bd5bc4f3": {
+    "title": "Expressing Robot Incapability",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ff9aa344fe987ce1": {
+    "title": "Establishing Appropriate Trust via Critical States",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_14670c094dee4d81": {
+    "title": "Supervising strong learners by amplifying weak experts",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_078647ecabd09671": {
+    "title": "Safe Reinforcement Learning with Model Uncertainty Estimates",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_34d8f5ef5275a7d8": {
+    "title": "Do Deep Generative Models Know What They Don't Know?",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_39f0309e9578100d": {
+    "title": "Applying Deep Learning To Airbnb Search",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f8a26d70a7cb3ec9": {
+    "title": "Toward an AI Physicist for Unsupervised Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f64435dc982350b1": {
+    "title": "One-Shot Hierarchical Imitation Learning of Compound Visuomotor Tasks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a52b988d2135f299": {
+    "title": "Neural Modular Control for Embodied Question Answering",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8ba0cd4cd001a53e": {
+    "title": "Efficiently Combining Human Demonstrations and Interventions for Safe Training of Autonomous Systems in Real-Time",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f27415a8ea03c98f": {
+    "title": "On the Effectiveness of Interval Bound Propagation for Training Verifiably Robust Models",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_9d9b44a5a1618980": {
+    "title": "A Marauder's Map of Security and Privacy in Machine Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1a1dc45a67dd7af2": {
+    "title": "Explaining Explanations in AI",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5b3fc1caecb2bdfb": {
+    "title": "A Model for General Intelligence",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_241a89b020f41ca2": {
+    "title": "MixTrain: Scalable Training of Verifiably Robust Neural Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_edcfb7b14bcd019f": {
+    "title": "A Geometric Perspective on the Transferability of Adversarial Directions",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ee44771acb20d893": {
+    "title": "Intrinsic Geometric Vulnerability of High-Dimensional Artificial Intelligence",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_3585f4371df3bbed": {
+    "title": "Towards Governing Agent's Efficacy: Action-Conditional $?$-VAE for Deep Transparent Reinforcement Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f219190c3da3ab10": {
+    "title": "Learning Latent Dynamics for Planning from Pixels",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f283b89018a0ba9f": {
+    "title": "Emergence of Addictive Behaviors in Reinforcement Learning Agents",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_aff106819250bbd2": {
+    "title": "Deeper Interpretability of Deep Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_86930a39f73f75bf": {
+    "title": "Safely Probabilistically Complete Real-Time Planning and Exploration in Unknown Environments",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_19f1abcbac7010a1": {
+    "title": "Scalable agent alignment via reward modeling: a research direction",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f9b3c39fa4529975": {
+    "title": "GAN Dissection: Visualizing and Understanding Generative Adversarial Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_347aeee287686933": {
+    "title": "Exploring Restart Distributions",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0475b257aaff02e4": {
+    "title": "Building Ethics into Artificial Intelligence",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b489d7cfa3b043cd": {
+    "title": "Building Ethically Bounded AI",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2731015320ee6b20": {
+    "title": "Human-AI Learning Performance in Multi-Armed Bandits",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_45bb5f743065a655": {
+    "title": "Learning Not to Learn: Training Deep Neural Networks with Biased Data",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_30d197f2abc4241f": {
+    "title": "Theoretically Principled Trade-off between Robustness and Accuracy",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b63f209cc6a759ef": {
+    "title": "Forecasting Transformative AI: An Expert Survey",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f950f006f5efb012": {
+    "title": "Lyapunov-based Safe Policy Optimization for Continuous Control",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_50eceef4c4b20c6e": {
+    "title": "Human-Centered Artificial Intelligence and Machine Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_90b5d7af9f5da8bf": {
+    "title": "Hybrid Models with Deep and Invertible Features",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7a25f9dac2f07281": {
+    "title": "Certified Adversarial Robustness via Randomized Smoothing",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e10bd434793cbcb9": {
+    "title": "Preferences Implicit in the State of the World",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fd1a8691241568fd": {
+    "title": "Deep Reinforcement Learning from Policy-Dependent Human Feedback",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_42b5c7670cdc45c0": {
+    "title": "Self-supervised Visual Feature Learning with Deep Neural Networks: A Survey",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_919161b4469fbbd2": {
+    "title": "Parenting: Safe Reinforcement Learning from Human Input",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c47368892bef3139": {
+    "title": "Regularizing Black-box Models for Improved Interpretability",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_96cde62c4dd6e7be": {
+    "title": "Meta-Weight-Net: Learning an Explicit Mapping For Sample Weighting",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4b97d1dac7514262": {
+    "title": "World Discovery Models",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0ab857cd2ee86671": {
+    "title": "Embedded Agency",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f5844f3a6e4347ca": {
+    "title": "Using Causal Analysis to Learn Specifications from Task Demonstrations",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9ab3cecfa4c1951e": {
+    "title": "Learning Exploration Policies for Navigation",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2fe8faa00c606c51": {
+    "title": "Learning Latent Plans from Play",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1bb63b4bece57ce3": {
+    "title": "Meta-Dataset: A Dataset of Datasets for Learning to Learn from Few Examples",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_83849de1b9cb57cf": {
+    "title": "Deep Reinforcement Learning with Feedback-based Exploration",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e0cdee14a523d8d2": {
+    "title": "Gradient Descent with Early Stopping is Provably Robust to Label Noise for Overparameterized Neural Networks",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_047b16216740d354": {
+    "title": "Predicting human decisions with behavioral theories and machine learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4ba32345a0367d2b": {
+    "title": "Optimization and Abstraction: A Synergistic Approach for Analyzing Neural Network Robustness",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e551f77f4bbceddc": {
+    "title": "Transfer of Adversarial Robustness Between Perturbation Types",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_6353ef31023a168c": {
+    "title": "Adversarial Examples Are Not Bugs, They Are Features",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2ff079707f380773": {
+    "title": "Cognitive Model Priors for Predicting Human Decisions",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_aa9a7266e2a3f6e8": {
+    "title": "Asymptotically Unambitious Artificial General Intelligence",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5d45e51f2ea6d22b": {
+    "title": "Adversarial Robustness as a Prior for Learned Representations",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7775b0d3b8cbad17": {
+    "title": "Can You Trust Your Model's Uncertainty? Evaluating Predictive Uncertainty Under Dataset Shift",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8e8ab37d7a89166c": {
+    "title": "An Extensible Interactive Interface for Agent Design",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0b830fb1671c291a": {
+    "title": "Likelihood Ratios for Out-of-Distribution Detection",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0a1c13b3bb93cd64": {
+    "title": "Weight Agnostic Neural Networks",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_30334862e967a234": {
+    "title": "Categorizing Wireheading in Partially Embedded Agents",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_060a27387c4518c0": {
+    "title": "Image Synthesis with a Single (Robust) Classifier",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6d55735612b0d645": {
+    "title": "Reinforcement Learning with Competitive Ensembles of Information-Constrained Primitives",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8921c4e2df86ea16": {
+    "title": "Generalizing from a few environments in safety-critical reinforcement learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a2fa77ab4077cf22": {
+    "title": "The Role of Cooperation in Responsible AI Development",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3514608b30257527": {
+    "title": "An Inductive Synthesis Framework for Verifiable Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fadbd429d0fa7b3f": {
+    "title": "Reducing malicious use of synthetic media research: Considerations and potential release practices for machine learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_82972a89dab65e8f": {
+    "title": "Reward Tampering Problems and Solutions in Reinforcement Learning: A Causal Influence Diagram Perspective",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_669a2a89fe0b6b86": {
+    "title": "Implications of Quantum Computing for Artificial Intelligence alignment research",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3d733b9f6a6b6091": {
+    "title": "Testing Robustness Against Unforeseen Adversaries",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f48be4c3fb9d9ad0": {
+    "title": "Release Strategies and the Social Impacts of Language Models",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_855de84aa73b3e51": {
+    "title": "Achieving Verified Robustness to Symbol Substitutions via Interval Bound Propagation",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4f0c4f943196c1b6": {
+    "title": "Meta-Inverse Reinforcement Learning with Probabilistic Context Variables",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_59f6f938d8b690b2": {
+    "title": "Formal Language Constraints for Markov Decision Processes",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_73478b418cc33143": {
+    "title": "Scaled Autonomy: Enabling Human Operators to Control Robot Fleets",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9bb1056693c6746e": {
+    "title": "On the Utility of Learning about Humans for Human-AI Coordination",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5c831da76432b236": {
+    "title": "An Alternative Surrogate Loss for PGD-based Adversarial Testing",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6026676ef70b61b3": {
+    "title": "Meta-World: A Benchmark and Evaluation for Multi-Task and Meta Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d2f51e0350d35221": {
+    "title": "A Hamilton-Jacobi Reachability-Based Framework for Predicting and Analyzing Human Motion for Safe Planning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6c033586fd63cd2e": {
+    "title": "On the Measure of Intelligence",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5223826fba8bc976": {
+    "title": "Nonverbal Robot Feedback for Human Teachers",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_135efea1cd78b777": {
+    "title": "(When) Is Truth-telling Favored in AI Debate?",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_623d2a613c808d33": {
+    "title": "Scaling Out-of-Distribution Detection for Real-World Settings",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cdb5c302cf99a7be": {
+    "title": "SafeLife 1.0: Exploring Side Effects in Complex Environments",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_352fdb904551171a": {
+    "title": "Optimal Policies Tend to Seek Power",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fae8082a3663346b": {
+    "title": "Learning Efficient Representation for Intrinsic Motivation",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bedbb9cfa9a577eb": {
+    "title": "Deep Ensembles: A Loss Landscape Perspective",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e05f8c3e7a81ae95": {
+    "title": "Learning Human Objectives by Evaluating Hypothetical Behavior",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ecfece2c5b40a7df": {
+    "title": "Dota 2 with Large Scale Deep Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f69600bf4fb8749b": {
+    "title": "Generative Teaching Networks: Accelerating Neural Architecture Search by Learning to Generate Synthetic Training Data",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b09f079287d7fbd3": {
+    "title": "Mastering Complex Control in MOBA Games with Deep Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fa408ad6b951e2be": {
+    "title": "Asking the Right Questions: Learning Interpretable Action Models Through Query Answering",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_01422b8e083200ef": {
+    "title": "The Logic of Strategic Assets: From Oil to Artificial Intelligence",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bd414a44f110c5bc": {
+    "title": "Beyond Near- and Long-Term: Towards a Clearer Account of Research Priorities in AI Ethics and Society",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_894271b0598a47c6": {
+    "title": "The Incentives that Shape Behaviour",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6311d79b1c153e4a": {
+    "title": "Silly rules improve the capacity of agents to learn stable enforcement and compliance behaviors",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_79c7fe8d20495ec5": {
+    "title": "The Conditional Entropy Bottleneck",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fa2a0311913b34e3": {
+    "title": "CEB Improves Model Robustness",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_646147045c9c2ce6": {
+    "title": "Safe Imitation Learning via Fast Bayesian Reward Inference from Preferences",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a0da85a1768c4325": {
+    "title": "Coherent Gradients: An Approach to Understanding Generalization in Gradient Descent-based Optimization",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_44220c5f671b2e28": {
+    "title": "TanksWorld: A Multi-Agent Environment for AI Safety Research",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_6e217576bd92ec66": {
+    "title": "Generalized Hindsight for Reinforcement Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1cf3dc49f86f8b07": {
+    "title": "Pruned Neural Networks are Surprisingly Modular",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2869e3c18f717d28": {
+    "title": "An empirical investigation of the challenges of real-world reinforcement learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_160879eef4774db7": {
+    "title": "Agent57: Outperforming the Atari Human Benchmark",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ca295111ff1ec76d": {
+    "title": "Certifiable Robustness to Adversarial State Uncertainty in Deep Reinforcement Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ce9119bdee8da16b": {
+    "title": "Toward Trustworthy AI Development: Mechanisms for Supporting Verifiable Claims",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_424bac6c22c04486": {
+    "title": "BERT-ATTACK: Adversarial Attack Against BERT Using BERT",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a644f0a3cb02d2e2": {
+    "title": "Pitfalls of learning a reward function online",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_98c0ce5ebb1c5dc9": {
+    "title": "Offline Reinforcement Learning: Tutorial, Review, and Perspectives on Open Problems",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6f3bebfdf31991d1": {
+    "title": "Measuring the Algorithmic Efficiency of Neural Networks",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cf093524c33472b7": {
+    "title": "Language Conditioned Imitation Learning over Unstructured Data",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_81e89e9c2a187565": {
+    "title": "Rational Consensus",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3ff44c4c933a57fc": {
+    "title": "What Makes for Good Views for Contrastive Learning?",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_af691406a00ffa9a": {
+    "title": "From ImageNet to Image Classification: Contextualizing Progress on Benchmarks",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d57f07c9b5b2fcaa": {
+    "title": "Curiosity Killed or Incapacitated the Cat and the Asymptotically Optimal Agent",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_581e6b835ead35ec": {
+    "title": "Reinforcement Learning Under Moral Uncertainty",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bc1ffc64424f8b74": {
+    "title": "AI Research Considerations for Human Existential Safety (ARCHES)",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a7adb7958fc7de7b": {
+    "title": "Pessimism About Unknown Unknowns Inspires Conservatism",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c45a03222f9a2430": {
+    "title": "Robust Learning with Frequency Domain Regularization",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1b99331610432995": {
+    "title": "Decolonial AI: Decolonial Theory as Sociotechnical Foresight in Artificial Intelligence",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8d6bfe9fd2b3c455": {
+    "title": "Machine Learning Explainability for External Stakeholders",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_74d2bed93d6eaa90": {
+    "title": "Hidden Incentives for Auto-Induced Distributional Shift",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9e6cbed97f1b3bc3": {
+    "title": "Neurosymbolic Reinforcement Learning with Formally Verified Exploration",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b4892a585fac1e8c": {
+    "title": "Learning Rewards from Linguistic Feedback",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5cb441d6c32c9e98": {
+    "title": "Safe Reinforcement Learning with Natural Language Constraints",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_18f734504931d5cf": {
+    "title": "An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_59be6f1812581416": {
+    "title": "Learning to be Safe: Deep RL with a Safety Critic",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f699ce072a0d412e": {
+    "title": "Recovery RL: Safe Reinforcement Learning with Learned Recovery Zones",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0da8cb466c437708": {
+    "title": "A Theory of Universal Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a76d89c0283d4a2e": {
+    "title": "Performance of Bounded-Rational Agents With the Ability to Self-Modify",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9395c3d0914d369d": {
+    "title": "Preventing Repeated Real World AI Failures by Cataloging Incidents: The AI Incident Database",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0631100f62ec42fb": {
+    "title": "REALab: An Embedded Perspective on Tampering",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a4d7c73ba1684f7f": {
+    "title": "Value Alignment Verification",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_84120dc4b15ae389": {
+    "title": "An overview of 11 proposals for building safe advanced AI",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_eaef206260f37f45": {
+    "title": "Extracting Training Data from Large Language Models",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_26323c8f3a2e6509": {
+    "title": "Evaluating the Robustness of Collaborative Agents",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3c7ec65d65c78749": {
+    "title": "Shielding Atari Games with Bounded Prescience",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_218ce086ce67d573": {
+    "title": "Accumulating Risk Capital Through Investing in Cooperation",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cbd42f5f1fdb1a3b": {
+    "title": "Agent Incentives: A Causal Perspective",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_dadd385d71c754d2": {
+    "title": "Understanding the Capabilities, Limitations, and Societal Impact of Large Language Models",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_62ef0e364eab5971": {
+    "title": "Consequences of Misaligned AI",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c171694c2a004f27": {
+    "title": "AI Development for the Public Interest: From Abstraction Traps to Sociotechnical Risks",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b521f441eb2544a1": {
+    "title": "Zero-Shot Text-to-Image Generation",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2693c7142eae6286": {
+    "title": "Causal Analysis of Agent Behavior for AI Safety",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7f8331f6c517ac35": {
+    "title": "Pretrained Transformers as Universal Computation Engines",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3f1c98bc443cac76": {
+    "title": "The AI Index 2021 Annual Report",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_da2deeeadbeab086": {
+    "title": "Replacing Rewards with Examples: Example-Based Policy Search via Recursive Classification",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_53c3414e76f6b1bc": {
+    "title": "Alignment of Language Agents",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_441024d88860cc55": {
+    "title": "Detection of Dataset Shifts in Learning-Enabled Cyber-Physical Systems using Variational Autoencoder for Regression",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_31a5fe3f499ab05b": {
+    "title": "Gradient-based Adversarial Attacks against Text Transformers",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a57f6329c975e596": {
+    "title": "Ethics and Governance of Artificial Intelligence: Evidence from a Survey of Machine Learning Researchers",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0a11a1aed371713f": {
+    "title": "Leveraging Sparse Linear Layers for Debuggable Deep Networks",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_50e653fce3d60282": {
+    "title": "Axes for Sociotechnical Inquiry in AI Research",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_aa2a65a3e15dd26d": {
+    "title": "Agree to Disagree: When Deep Learning Models With Identical Architectures Produce Distinct Explanations",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cc4d70762dab69e1": {
+    "title": "AI and Shared Prosperity",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b6f519be57b453ca": {
+    "title": "Goal Misgeneralization in Deep Reinforcement Learning",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_05f9af1daa2926cf": {
+    "title": "Provably Robust Detection of Out-of-distribution Data (almost) for free",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4d86e7039be72db7": {
+    "title": "Engines of Power: Electricity, AI, and General-Purpose Military Transformations",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_022a0b73d5f487fa": {
+    "title": "There Is No Turning Back: A Self-Supervised Approach for Reversibility-Aware Reinforcement Learning",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ea0d3cf025dcd154": {
+    "title": "PEBBLE: Feedback-Efficient Interactive Reinforcement Learning via Relabeling Experience and Unsupervised Pre-training",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ac7c2b65f2dc94f9": {
+    "title": "Revisiting the Calibration of Modern Neural Networks",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6473bf92d37686f5": {
+    "title": "How Well do Feature Visualizations Support Causal Understanding of CNN Activations?",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6e0f2c882ed2ded9": {
+    "title": "The MineRL BASALT Competition on Learning from Human Feedback",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ca9b96625c777525": {
+    "title": "What are you optimizing for? Aligning Recommender Systems with Human Values",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e413f8bb0dea4865": {
+    "title": "Standardized Max Logits: A Simple yet Effective Approach for Identifying Unexpected Road Obstacles in Urban-Scene Segmentation",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_62048503a42e7698": {
+    "title": "Open-Ended Learning Leads to Generally Capable Agents",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4c1601e7b988fad5": {
+    "title": "Soft Calibration Objectives for Neural Networks",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f9ade5d3a5d60077": {
+    "title": "Triggering Failures: Out-Of-Distribution detection by learning from local adversarial attacks in Semantic Segmentation",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0b1f4debe314fa2e": {
+    "title": "Asleep at the Keyboard? Assessing the Security of GitHub Copilot's Code Contributions",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_80458dc82661aceb": {
+    "title": "Robust fine-tuning of zero-shot models",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_40199422e213e467": {
+    "title": "Augmenting Decision Making via Interactive What-If Analysis",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_43da39bb4352078c": {
+    "title": "Challenges in Detoxifying Language Models",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_70b81709b37af2f6": {
+    "title": "Recursively Summarizing Books with Human Feedback",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_380bb59b80887c6e": {
+    "title": "Cartesian Frames",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c328090bc4305415": {
+    "title": "RAFT: A Real-World Few-Shot Text Classification Benchmark",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_03b945a38102e081": {
+    "title": "Can Machines Learn Morality? The Delphi Experiment",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_27c6059e550e8ff6": {
+    "title": "Certified Patch Robustness via Smoothed Vision Transformers",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8fad072693ba66f9": {
+    "title": "Quantifying Local Specialization in Deep Neural Networks",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e66bebdb252a6220": {
+    "title": "Analyzing Dynamic Adversarial Training Data in the Limit",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_15eb203180cab2f1": {
+    "title": "MEMO: Test Time Robustness via Adaptation and Augmentation",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_df96fcd4101b5279": {
+    "title": "What Would Jiminy Cricket Do? Towards Agents That Behave Morally",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6e27957f99ea08be": {
+    "title": "Toward a Theory of Justice for Artificial Intelligence",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_32193b4c5013c697": {
+    "title": "AI Ethics Statements -- Analysis and lessons learnt from NeurIPS Broader Impact Statements",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5249c85b08bb42ca": {
+    "title": "Adversarial GLUE: A Multi-Task Benchmark for Robustness Evaluation of Language Models",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_43f3d019e5a786f9": {
+    "title": "B-Pref: Benchmarking Preference-Based Reinforcement Learning",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_88857fbe01e7fa53": {
+    "title": "Linguistic Cues of Deception in a Multilingual April Fools' Day Context",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b990438c3d2f4172": {
+    "title": "Data Augmentation Can Improve Robustness",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b344183bfa91e639": {
+    "title": "Solving Probability and Statistics Problems by Program Synthesis",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_20e257a61198f4b8": {
+    "title": "Discrete Representations Strengthen Vision Transformer Robustness",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f3ed9ac8b53110c3": {
+    "title": "ReAct: Out-of-distribution Detection With Rectified Activations",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_02cb990df1910ff1": {
+    "title": "Normative Disagreement as a Challenge for Cooperative AI",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_122063637b044550": {
+    "title": "Pyramid Adversarial Training Improves ViT Performance",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c07dc0e7916bb37d": {
+    "title": "Certified Adversarial Defenses Meet Out-of-Distribution Corruptions: Benchmarking Robustness and Simple Baselines",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_26f49ad8f2b64b02": {
+    "title": "A General Language Assistant as a Laboratory for Alignment",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_481bd6001ca24466": {
+    "title": "PixMix: Dreamlike Pictures Comprehensively Improve Safety Measures",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b743fa8ab99bc9f2": {
+    "title": "Execute Order 66: Targeted Data Poisoning for Reinforcement Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_386e990bbee71f34": {
+    "title": "Robust Self-Supervised Audio-Visual Speech Recognition",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c8c6e6b65ff731ba": {
+    "title": "The Effects of Reward Misspecification: Mapping and Mitigating Misaligned Models",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a8b94f643fb93c80": {
+    "title": "Safe Deep RL in 3D Environments using Human Feedback",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fef5f9443f146471": {
+    "title": "Identifying Adversarial Attacks on Text Classifiers",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9ee7e2ee3bd59130": {
+    "title": "Towards Safe Reinforcement Learning with a Safety Editor Policy",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2f21646ae78f5f10": {
+    "title": "Certifying Model Accuracy under Distribution Shifts",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d3e76392f9627e93": {
+    "title": "VOS: Learning What You Don't Know by Virtual Outlier Synthesis",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0dfde4014fcd105b": {
+    "title": "Certifying Out-of-Domain Generalization for Blackbox Functions",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_964be84536460180": {
+    "title": "The Met Dataset: Instance-level Recognition for Artworks",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5b9b42f6b9b6a092": {
+    "title": "Red Teaming Language Models with Language Models",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_15a7dd0611e9002e": {
+    "title": "Locating and Editing Factual Associations in GPT",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d41c93555f5da094": {
+    "title": "Predicting Out-of-Distribution Error with the Projection Norm",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a26655f80e9f2932": {
+    "title": "Predictability and Surprise in Large Generative Models",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3a9a29b53f0b3b7e": {
+    "title": "Safe Reinforcement Learning by Imagining the Near Future",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_81a46f2c0a82c9ff": {
+    "title": "Deconstructing Distributions: A Pointwise Framework of Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_42e2a4ce0af6455a": {
+    "title": "Retrieval Augmented Classification for Long-Tail Visual Recognition",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_71844bc4a557c4d1": {
+    "title": "3D Common Corruptions and Data Augmentation",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_16b35f91b280207d": {
+    "title": "The Singularity Controversy, Part I: Lessons Learned and Open Questions: Conclusions from the Battle on the Legitimacy of the Debate",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ba7514433f5f71f0": {
+    "title": "Research Priorities for Robust and Beneficial Artificial Intelligence",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_058f69adbea22c2d": {
+    "title": "Designing Intelligent Instruments",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2fd7f04f95ad5171": {
+    "title": "The Singularity May Never Be Near",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_176a4ddb834e0c5f": {
+    "title": "Latent Skill Embedding for Personalized Lesson Sequence Recommendation",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ca4584e9771465a2": {
+    "title": "Moving Beyond the Turing Test with the Allen AI Science Challenge",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e57df4802928e8e2": {
+    "title": "An artificial intelligence tool for heterogeneous team formation in the classroom",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9330b17f4620fb2e": {
+    "title": "Towards A Virtual Assistant That Can Be Taught New Tasks In Any Domain By Its End-Users",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2fd3950d429dc65a": {
+    "title": "A Hybrid POMDP-BDI Agent Architecture with Online Stochastic Planning and Plan Caching",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2b4f7f998245e241": {
+    "title": "Predicting Enemy's Actions Improves Commander Decision-Making",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_533541b26e68390c": {
+    "title": "Graph Aggregation",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a18e21777c6faa10": {
+    "title": "Long-Term Trends in the Public Perception of Artificial Intelligence",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4c0cd90e3924e341": {
+    "title": "A stochastically verifiable autonomous control architecture with reasoning",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e62b5fe6bcdefb18": {
+    "title": "Improving Policy Gradient by Exploring Under-appreciated Rewards",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_db7e00145997644b": {
+    "title": "Neuro-symbolic EDA-based Optimisation using ILP-enhanced DBNs",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_aef861ddf7738833": {
+    "title": "A Base Camp for Scaling AI",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_402f917ef1f85b47": {
+    "title": "Designing a Safe Autonomous Artificial Intelligence Agent based on Human Self-Regulation",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_db731640470abad7": {
+    "title": "Practical Reasoning with Norms for Autonomous Software Agents (Full Edition)",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d0d350b2ac6e04b8": {
+    "title": "Plan Explanations as Model Reconciliation: Moving Beyond Explanation as Soliloquy",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_26e147e49fc695c9": {
+    "title": "Synergistic Team Composition",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_beb12a23a4297645": {
+    "title": "Don't Fear the Reaper: Refuting Bostrom's Superintelligence Argument",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0e186b0d516bdeb5": {
+    "title": "Strategically knowing how",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e434ded2d51769f0": {
+    "title": "The Singularity May Be Near",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_90075e5d06ca1445": {
+    "title": "Responsible Autonomy",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3f2a112d14cc4080": {
+    "title": "RAIL: Risk-Averse Imitation Learning",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b995fa8df519db15": {
+    "title": "Using Program Induction to Interpret Transition System Dynamics",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7cdb1233cf82deb9": {
+    "title": "Safe Reinforcement Learning via Shielding",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_01e708118256c867": {
+    "title": "Knowledge Transfer Between Artificial Intelligence Systems",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_05f3a92ca4a98b9f": {
+    "title": "Autonomous Agents Modelling Other Agents: A Comprehensive Survey and Open Problems",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_08b82a9d28b9a5af": {
+    "title": "Using KL-divergence to focus Deep Visual Explanation",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_a8804756ba4b9e2c": {
+    "title": "Deterministic Policy Optimization by Combining Pathwise and Score Function Estimators for Discrete Action Spaces",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b05147510dbab92f": {
+    "title": "A Berkeley View of Systems Challenges for AI",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_37ebf1f6d3262bef": {
+    "title": "Antifragility for Intelligent Autonomous Systems",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_36c9d30e5926d515": {
+    "title": "Value Alignment, Fair Play, and the Rights of Service Robots",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9c87c9876c628a0d": {
+    "title": "Institutional Metaphors for Designing Large-Scale Distributed AI versus AI Techniques for Running Institutions",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a69b3787f140388f": {
+    "title": "The Challenge of Crafting Intelligible Intelligence",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1d2c96ed448dacfc": {
+    "title": "Artificial Intelligence and its Role in Near Future",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a2adaf3e37e06221": {
+    "title": "First Experiments with a Flexible Infrastructure for Normative Reasoning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_fe539961451698cb": {
+    "title": "A Logic of Agent Organizations",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4776a7ac86b1c7dd": {
+    "title": "Automated Mechanism Design via Neural Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0a373355a323506a": {
+    "title": "Understanding the Meaning of Understanding",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_e5d9799933b8dfd5": {
+    "title": "Interpretable to Whom? A Role-based Model for Analyzing Interpretable Machine Learning Systems",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fa6d0106af1c5665": {
+    "title": "The Foundations of Deep Learning with a Path Towards General Intelligence",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b4ac7edad0c3c691": {
+    "title": "Knowledge Integration for Disease Characterization: A Breast Cancer Example",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9bba061071a331e9": {
+    "title": "Adding Neural Network Controllers to Behavior Trees without Destroying Performance Guarantees",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cabb1d4226057aa6": {
+    "title": "Optimizing Agent Behavior over Long Time Scales by Transporting Value",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_19553eb276e20e1b": {
+    "title": "Mimetic vs Anchored Value Alignment in Artificial Intelligence",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_55b08e232187491f": {
+    "title": "The Responsibility Quantification (ResQu) Model of Human Interaction with Automation",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4af897b4f7e8de9e": {
+    "title": "Economics of Human-AI Ecosystem: Value Bias and Lost Utility in Multi-Dimensional Gaps",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_16e9dd5f9342483a": {
+    "title": "Deep Learning Application in Security and Privacy -- Theory and Practice: A Position Paper",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8c44535e5835b120": {
+    "title": "Linking Artificial Intelligence Principles",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_f9f91ab90cec59be": {
+    "title": "IRLAS: Inverse Reinforcement Learning for Architecture Search",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b4656685cd55f878": {
+    "title": "Making AI meaningful again",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_61517cf54fe17bd5": {
+    "title": "A New Tensioning Method using Deep Reinforcement Learning for Surgical Pattern Cutting",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1ae584b18d1d3cb2": {
+    "title": "PUTWorkbench: Analysing Privacy in AI-intensive Systems",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f568f9a05f383d1d": {
+    "title": "Ask Not What AI Can Do, But What AI Should Do: Towards a Framework of Task Delegability",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8dfe174756251e0d": {
+    "title": "Hacking Google reCAPTCHA v3 using Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_266a1fefecfd5b20": {
+    "title": "Challenges for an Ontology of Artificial Intelligence",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6d9c643dc346070e": {
+    "title": "The Ethics of AI Ethics -- An Evaluation of Guidelines",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4e6e866ec66e13ee": {
+    "title": "Improving Safety in Reinforcement Learning Using Model-Based Architectures and Human Intervention",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2c321a00435b902b": {
+    "title": "Designing Normative Theories for Ethical and Legal Reasoning: LogiKEy Framework, Methodology, and Tool Support",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7260b5451ca708a2": {
+    "title": "Informed Machine Learning -- A Taxonomy and Survey of Integrating Knowledge into Learning Systems",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_486e51b6eca9e021": {
+    "title": "Extending planning knowledge using ontologies for goal opportunities",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ec9006a24eeee38c": {
+    "title": "Counterfactual Visual Explanations",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_45fa4bad8ce1fd79": {
+    "title": "Risk Structures: Towards Engineering Risk-aware Autonomous Systems",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cbf09e13232824de": {
+    "title": "Knowing When to Stop: Evaluation and Verification of Conformity to Output-size Specifications",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f3f72edbee43cb38": {
+    "title": "The relationship between Biological and Artificial Intelligence",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f2b465bed533cd9f": {
+    "title": "Lie on the Fly: Strategic Voting in an Iterative Preference Elicitation Process",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1d8c98b2b9f9dbab": {
+    "title": "From What to How: An Initial Review of Publicly Available AI Ethics Tools, Methods and Research to Translate Principles into Practices",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a9df46959c30e10d": {
+    "title": "On modelling the emergence of logical thinking",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9b07c785b4cee566": {
+    "title": "Better Future through AI: Avoiding Pitfalls and Guiding AI Towards its Full Potential",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_f39e06c0ba936138": {
+    "title": "Learner-aware Teaching: Inverse Reinforcement Learning with Preferences and Constraints",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_18def41ad9ebddf1": {
+    "title": "An AGI with Time-Inconsistent Preferences",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_acb8ec6d2eca4a07": {
+    "title": "Integration of Imitation Learning using GAIL and Reinforcement Learning using Task-achievement Rewards via Probabilistic Graphical Model",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5de2b48b2c1f89fb": {
+    "title": "Artificial Intelligence Governance and Ethics: Global Perspectives",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3f342b07edb81627": {
+    "title": "Grounding Value Alignment with Ethical Principles",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8c5a3cc4714aba1a": {
+    "title": "A system of different layers of abstraction for artificial intelligence",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bcfb223ceb5af178": {
+    "title": "Towards a Theory of Intentions for Human-Robot Collaboration",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a7ee381d857e98a8": {
+    "title": "Neural Simplex Architecture",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_423dcda046865535": {
+    "title": "Better AI through Logical Scaffolding",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_eb20cd0d24a7d685": {
+    "title": "Emergent Tool Use From Multi-Agent Autocurricula",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1dc156388ea7c94a": {
+    "title": "From the Internet of Information to the Internet of Intelligence",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4a42a1e94a9df88b": {
+    "title": "Towards Deployment of Robust AI Agents for Human-Machine Partnerships",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ad8f9548298ee546": {
+    "title": "Can We Distinguish Machine Learning from Human Learning?",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_18135125de8f50d6": {
+    "title": "Improving Generalization in Meta Reinforcement Learning using Learned Objectives",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3507b1dfd2ca4512": {
+    "title": "Asking Easy Questions: A User-Friendly Approach to Active Reward Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0ea949bb15660a63": {
+    "title": "The Quest for Interpretable and Responsible Artificial Intelligence",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_a5e4ac92c362434f": {
+    "title": "Using AI/ML to gain situational understanding from passive network observations",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1e39f0a284624af1": {
+    "title": "How can AI Automate End-to-End Data Science?",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0e7d9ea18dd95c60": {
+    "title": "Generating Justifications for Norm-Related Agent Decisions",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b7e2676767766152": {
+    "title": "The relationship between trust in AI and trustworthy machine learning technologies",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8ac12fda3d813829": {
+    "title": "Adaptive Online Planning for Continual Lifelong Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_dcd0a0556ebfc56a": {
+    "title": "Interactive AI with a Theory of Mind",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_285e08b9eeca3f26": {
+    "title": "Anti-Alignments -- Measuring The Precision of Process Models and Event Logs",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f1558dd5b768a522": {
+    "title": "Why we need an AI-resilient society",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8284c45318e073dc": {
+    "title": "Questions to Guide the Future of Artificial Intelligence Research",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6963078acea43dba": {
+    "title": "Defining AI in Policy versus Practice",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b9a647ad554c990a": {
+    "title": "Uncertainty-Based Out-of-Distribution Classification in Deep Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_77b8610cfe330f24": {
+    "title": "Auditing and Debugging Deep Learning Models via Decision Boundaries: Individual-level and Group-level Analysis",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_01150a46b8a08cef": {
+    "title": "A Framework for Democratizing AI",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fae9b2be0f99a179": {
+    "title": "Activism by the AI Community: Analysing Recent Achievements and Future Prospects",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e6d0c3b2488775e3": {
+    "title": "Teaching Software Engineering for AI-Enabled Systems",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d2386b5bab1151ae": {
+    "title": "Explaining Data-Driven Decisions made by AI Systems: The Counterfactual Approach",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_46a3f714374e488d": {
+    "title": "Engineering AI Systems: A Research Agenda",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f528c0b9ea26bd08": {
+    "title": "Optimal by Design: Model-Driven Synthesis of Adaptation Strategies for Autonomous Systems",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_361d1c2119b692fd": {
+    "title": "Bridging the Gap: Providing Post-Hoc Symbolic Explanations for Sequential Decision-Making Problems with Inscrutable Representations",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_94c39b5469e86981": {
+    "title": "Leveraging Rationales to Improve Human Task Performance",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8c6ea1b019a85b11": {
+    "title": "Analyzing Differentiable Fuzzy Logic Operators",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0ae9c9a9e757ef78": {
+    "title": "A Road Map to Strong Intelligence",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e7bcd86ebcadbd8e": {
+    "title": "The Pragmatic Turn in Explainable Artificial Intelligence (XAI)",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_38dcb38fbe42141d": {
+    "title": "Cautious Reinforcement Learning with Logical Constraints",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3dfc5c5b2dbf412a": {
+    "title": "On Safety Assessment of Artificial Intelligence",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_50e1a7109df31a84": {
+    "title": "Marketplace for AI Models",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_393de4ce26114b76": {
+    "title": "Two Decades of AI4NETS-AI/ML for Data Networks: Challenges & Research Directions",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bb50754d1bf1a3e3": {
+    "title": "Dividing the Ontology Alignment Task with Semantic Embeddings and Logic-based Modules",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_56272308af8ac1b8": {
+    "title": "The Conflict Between People's Urge to Punish AI and Legal Systems",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d706ac5200178150": {
+    "title": "Three Modern Roles for Logic in AI",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_53872389fe614b7b": {
+    "title": "Responsible AI and Its Stakeholders",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_3aad3548ca62dc4d": {
+    "title": "Is the Most Accurate AI the Best Teammate? Optimizing AI for Teamwork",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_294dc6a8d1cbb403": {
+    "title": "A multi-component framework for the analysis and design of explainable artificial intelligence",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_05d065dde75a5055": {
+    "title": "AI Forensics: Did the Artificial Intelligence System Do It? Why?",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f794febf4f9decf7": {
+    "title": "Ethical Considerations for AI Researchers",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_87702a5b51dcf88e": {
+    "title": "The Social Contract for AI",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_e8c73364ac5f27fa": {
+    "title": "Formal Verification of End-to-End Learning in Cyber-Physical Systems: Progress and Challenges",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d802a08e209a39aa": {
+    "title": "SAMBA: Safe Model-Based & Active Reinforcement Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b4b1eff26b3cd1d9": {
+    "title": "IReEn: Reverse-Engineering of Black-Box Functions via Iterative Neural Program Synthesis",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_25cf381fb83a38b6": {
+    "title": "Safe Reinforcement Learning via Curriculum Induction",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_92d190e68f6baabb": {
+    "title": "Does the Whole Exceed its Parts? The Effect of AI Explanations on Complementary Team Performance",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4ec878851f211ef9": {
+    "title": "Unifying Model Explainability and Robustness via Machine-Checkable Concepts",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e303c3cd7f0d8ebf": {
+    "title": "Customized Handling of Unintended Interface Operation in Assistive Robots",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ee8a49ce57bed686": {
+    "title": "Failures of Contingent Thinking",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0b2cdf50657fa90e": {
+    "title": "Technologies for Trustworthy Machine Learning: A Survey in a Socio-Technical Context",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b4fccbd27d6e5e6a": {
+    "title": "Improving Competence for Reliable Autonomy",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c618fea8fc278406": {
+    "title": "Bridging the Imitation Gap by Adaptive Insubordination",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_56d0c65d1754d563": {
+    "title": "Toward Campus Mail Delivery Using BDI",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0e7a23bf62ca3f62": {
+    "title": "Collecting the Public Perception of AI and Robot Rights",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_616a90eae506a42d": {
+    "title": "Forward and inverse reinforcement learning sharing network weights and hyperparameters",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_58d2f516697b4e3a": {
+    "title": "Artificial Intelligence is stupid and causal reasoning won't fix it",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_86d35e688b6e822a": {
+    "title": "Runtime-Safety-Guided Policy Repair",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0dc012241e048d4d": {
+    "title": "A Composable Specification Language for Reinforcement Learning Tasks",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5d7cfd2d76544f71": {
+    "title": "A Framework for Improving Scholarly Neural Network Diagrams",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c237d4275da9341e": {
+    "title": "The AIQ Meta-Testbed: Pragmatically Bridging Academic AI Testing and Industrial Q Needs",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ebbdc0ac967f34cd": {
+    "title": "Towards the Quantification of Safety Risks in Deep Neural Networks",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e48b8a2aed3d856e": {
+    "title": "Beneficial and Harmful Explanatory Machine Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_55080c9319c2415f": {
+    "title": "Learnable Strategies for Bilateral Agent Negotiation over Multiple Issues",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_52cdcc7c93c44156": {
+    "title": "Enterprise AI Canvas -- Integrating Artificial Intelligence into Business",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_eadaa3228b2bbaf9": {
+    "title": "Trust-Region Method with Deep Reinforcement Learning in Analog Design Space Exploration",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_efd2865183fd7466": {
+    "title": "Mediating Artificial Intelligence Developments through Negative and Positive Incentives",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ad6d23e1b1a90af6": {
+    "title": "Providing Actionable Feedback in Hiring Marketplaces using Generative Adversarial Networks",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_f5b852a2a9e67350": {
+    "title": "A framework for predicting, interpreting, and improving Learning Outcomes",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_230fb9bb493fe9e0": {
+    "title": "Information-Driven Adaptive Sensing Based on Deep Reinforcement Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f3812df783dc106f": {
+    "title": "Do's and Don'ts for Human and Digital Worker Integration",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_10237dc027826413": {
+    "title": "Chance-Constrained Control with Lexicographic Deep Reinforcement Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_95aad70e56a97db6": {
+    "title": "Exploring the Nuances of Designing (with/for) Artificial Intelligence",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e25da3f1799e8a25": {
+    "title": "Risk Assessment for Machine Learning Models",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d093b4fbe7c5d423": {
+    "title": "Learning Latent Representations to Influence Multi-Agent Interaction",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b788e4590d7267be": {
+    "title": "Emergent Road Rules In Multi-Agent Driving Environments",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_00ccb2340d8ada5a": {
+    "title": "BARS: Joint Search of Cell Topology and Layout for Accurate and Efficient Binary ARchitectures",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_44bc639cf9816b05": {
+    "title": "Contract Scheduling With Predictions",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6eaa8320041fb81d": {
+    "title": "Interdisciplinary Approaches to Understanding Artificial Intelligence's Impact on Society",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_2da04dc77304832b": {
+    "title": "Exploring Fluent Query Reformulations with Text-to-Text Transformers and Reinforcement Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_106bc20476a32912": {
+    "title": "Taking Principles Seriously: A Hybrid Approach to Value Alignment",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0d1bdcf29c07ba19": {
+    "title": "Augmenting Policy Learning with Routines Discovered from a Single Demonstration",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3e08a4bd71197293": {
+    "title": "Antitrust and Artificial Intelligence (AAI): Antitrust Vigilance Lifecycle and AI Legal Reasoning Autonomy",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c54433ebfff783d7": {
+    "title": "Multi-Principal Assistance Games: Definition and Collegial Mechanisms",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_334413a1e3315407": {
+    "title": "Socially Responsible AI Algorithms: Issues, Purposes, and Challenges",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6ccfec6178816685": {
+    "title": "Bridging In- and Out-of-distribution Samples for Their Better Discriminability",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6c87991453243015": {
+    "title": "Teaming up with information agents",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_8e0b3bede15d2844": {
+    "title": "Adversarial Interaction Attack: Fooling AI to Misinterpret Human Intentions",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c7b84bc87ee9cfb7": {
+    "title": "Making Responsible AI the Norm rather than the Exception",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3220cd2617965b93": {
+    "title": "Fairness through Social Welfare Optimization",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cf6d86c6187b6551": {
+    "title": "Counterfactual Planning in AGI Systems",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e02500165c9882ce": {
+    "title": "Exploring Beyond-Demonstrator via Meta Learning-Based Reward Extrapolation",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_191e09b94ec233fd": {
+    "title": "A Decentralized Approach towards Responsible AI in Social Ecosystems",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_dff8aedeb662848f": {
+    "title": "Mitigating Negative Side Effects via Environment Shaping",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_913763e4d36b0f9e": {
+    "title": "On the Equilibrium Elicitation of Markov Games Through Information Design",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_beb53e03ce611e66": {
+    "title": "Machine Learning Model Development from a Software Engineering Perspective: A Systematic Literature Review",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2fa1b68cb500bcd1": {
+    "title": "How RL Agents Behave When Their Actions Are Modified",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9312ad006aca35cb": {
+    "title": "Training a Resilient Q-Network against Observational Interference",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f1a46dbfbe90205f": {
+    "title": "Software Architecture for Next-Generation AI Planning Systems",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_99cb587661c88b56": {
+    "title": "Beyond Fine-Tuning: Transferring Behavior in Reinforcement Learning",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4d29d4a065f90b60": {
+    "title": "Secure Evaluation of Knowledge Graph Merging Gain",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9985528a03f79df7": {
+    "title": "Evaluating Robustness of Counterfactual Explanations",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_378d3427c0ffac74": {
+    "title": "Symbolic Reinforcement Learning for Safe RAN Control",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_b71c7e1c9618e211": {
+    "title": "Towards Risk Modeling for Collaborative AI",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_7349535db7a4ab6a": {
+    "title": "Success Weighted by Completion Time: A Dynamics-Aware Evaluation Criteria for Embodied Navigation",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3887e5490a7a9880": {
+    "title": "Lyapunov Barrier Policy Optimization",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1717dd816d939c97": {
+    "title": "Systematic Mapping Study on the Machine Learning Lifecycle",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_59f90d6e3944f784": {
+    "title": "Combining Reward Information from Multiple Sources",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_715784c647249f72": {
+    "title": "Assured Learning-enabled Autonomy: A Metacognitive Reinforcement Learning Framework",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a359baed17693d64": {
+    "title": "Counterfactual Explanation with Multi-Agent Reinforcement Learning for Drug Target Prediction",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fcc1ea7b94857d53": {
+    "title": "W2WNet: a two-module probabilistic Convolutional Neural Network with embedded data cleansing functionality",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7bec26c394380c20": {
+    "title": "A Bayesian Approach to Identifying Representational Errors",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e1dbcfab2d880dae": {
+    "title": "Towards An Ethics-Audit Bot",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_0141cd563881ab4f": {
+    "title": "Voluntary safety commitments provide an escape from over-regulation in AI development",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cdeea8d88c36ce15": {
+    "title": "Artificial intelligence, human rights, democracy, and the rule of law: a primer",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ea8c2d32c2566698": {
+    "title": "The Atari Data Scraper",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5fd293522bc3b6b6": {
+    "title": "Action Advising with Advice Imitation in Deep Reinforcement Learning",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f0c09aed3d03e527": {
+    "title": "Causal Learning for Socially Responsible AI",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_73643a60bb86bf2f": {
+    "title": "A Framework for Ethical AI at the United Nations",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bae10359a6547ffd": {
+    "title": "pyBKT: An Accessible Python Library of Bayesian Knowledge Tracing Models",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7d73ab05546a6fcf": {
+    "title": "Hybrid Intelligence",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_41bc4ce3496b2fe9": {
+    "title": "RL-IoT: Reinforcement Learning to Interact with IoT Devices",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f02af23f63156be9": {
+    "title": "AI Risk Skepticism",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b92f2e30b3f18ed7": {
+    "title": "Finding the unicorn: Predicting early stage startup success through a hybrid intelligence method",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7b0d451e83568289": {
+    "title": "Hard Choices and Hard Limits for Artificial Intelligence",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a729a26f4f765bad": {
+    "title": "An Offline Risk-aware Policy Selection Method for Bayesian Markov Decision Processes",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_aa2397b1dcdda034": {
+    "title": "Towards a Mathematical Theory of Abstraction",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_49d1e059b5b2252b": {
+    "title": "Definitions of intent suitable for algorithms",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_96d146702316db21": {
+    "title": "Curriculum Design for Teaching via Demonstrations: Theory and Applications",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_357c9172db62c1a5": {
+    "title": "Synthesising Reinforcement Learning Policies through Set-Valued Inductive Rule Learning",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f9ac5781faaed74d": {
+    "title": "Developing a Fidelity Evaluation Approach for Interpretable Machine Learning",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_feb742285ce9f746": {
+    "title": "Hard Choices in Artificial Intelligence",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_950357c48af62862": {
+    "title": "Institutionalising Ethics in AI through Broader Impact Requirements",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b49589e94ad75d34": {
+    "title": "Not all users are the same: Providing personalized explanations for sequential decision making problems",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d196c5722d701595": {
+    "title": "The Threat of Offensive AI to Organizations",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_942a97fcf69f4e99": {
+    "title": "ML-Quadrat & DriotData: A Model-Driven Engineering Tool and a Low-Code Platform for Smart IoT Services",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_342c6984900004ff": {
+    "title": "Integrating Planning, Execution and Monitoring in the presence of Open World Novelties: Case Study of an Open World Monopoly Solver",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_93b71b609bfa6bfb": {
+    "title": "Aligning an optical interferometer with beam divergence control and continuous action space",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a1647aa4fae04ddf": {
+    "title": "Not Quite 'Ask a Librarian': AI on the Nature, Value, and Future of LIS",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a0c29a80d370bee9": {
+    "title": "aiSTROM -- A roadmap for developing a successful AI strategy",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_839c200889ebc513": {
+    "title": "Deep Adaptive Multi-Intention Inverse Reinforcement Learning",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_349b721fcb4e01ce": {
+    "title": "A Modulation Layer to Increase Neural Network Robustness Against Data Quality Issues",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_62e683d54a625bee": {
+    "title": "On the Veracity of Local, Model-agnostic Explanations in Audio Classification: Targeted Investigations with Adversarial Examples",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ffcecabe153f9af6": {
+    "title": "Towards Industrial Private AI: A two-tier framework for data and model security",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ef2214c5eb3122eb": {
+    "title": "A Reflection on Learning from Data: Epistemology Issues and Limitations",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_46ba239757968f3f": {
+    "title": "Discovering User-Interpretable Capabilities of Black-Box Planning Agents",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_844cb18b7b1f087b": {
+    "title": "An Ethical Framework for Guiding the Development of Affectively-Aware Artificial Intelligence",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_56ff800292644bea": {
+    "title": "The Role of Social Movements, Coalitions, and Workers in Resisting Harmful Artificial Intelligence and Contributing to the Development of Responsible AI",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e279806c12c8a668": {
+    "title": "A Decision Model for Decentralized Autonomous Organization Platform Selection: Three Industry Case Studies",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_577ffc18173d346a": {
+    "title": "DySR: A Dynamic Representation Learning and Aligning based Model for Service Bundle Recommendation",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f53e1e0c49789ad6": {
+    "title": "Beyond Fairness Metrics: Roadblocks and Challenges for Ethical AI in Practice",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_95b381a292b906e9": {
+    "title": "A Framework for Understanding AI-Induced Field Change: How AI Technologies are Legitimized and Institutionalized",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ec9b13447a3e2519": {
+    "title": "Safe Transformative AI via a Windfall Clause",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1a84b206594ab34b": {
+    "title": "Learning Causal Models of Autonomous Agents using Interventions",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c085d2d1d8ede633": {
+    "title": "With One Voice: Composing a Travel Voice Assistant from Re-purposed Models",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_759a6e91ea8575e1": {
+    "title": "Why and How Governments Should Monitor AI Development",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4d68272ca50e9711": {
+    "title": "Problem Learning: Towards the Free Will of Machines",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_714861efdafd1851": {
+    "title": "Towards Resilient Artificial Intelligence: Survey and Research Issues",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b2ad8022e71fd93f": {
+    "title": "Learning to Assist Agents by Observing Them",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6843e44989aaddcc": {
+    "title": "Procedure Planning in Instructional Videos via Contextual Modeling and Model-based Policy Learning",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c515598ed82b0e38": {
+    "title": "Thinking Fast and Slow in AI: the Role of Metacognition",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3f5d47ddec0cbf30": {
+    "title": "Fingerprinting Multi-exit Deep Neural Network Models via Inference Time",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bb5283252d7c5fdc": {
+    "title": "Robustness of different loss functions and their impact on networks learning capability",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ae08d781c06efe3d": {
+    "title": "Evaluating the Faithfulness of Importance Measures in NLP by Recursively Masking Allegedly Important Tokens and Retraining",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e2b71b5b174e59cc": {
+    "title": "Improving End-To-End Modeling for Mispronunciation Detection with Effective Augmentation Mechanisms",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d9b74722526e4fcd": {
+    "title": "Value alignment: a formal approach",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6ae1ff25b772be68": {
+    "title": "Risks of AI Foundation Models in Education",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_38262fb2240896fa": {
+    "title": "QuantifyML: How Good is my Machine Learning Model?",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ffb3cdbe1647ac78": {
+    "title": "Understanding Interlocking Dynamics of Cooperative Rationalization",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_efc0cd3231bac3fe": {
+    "title": "Learning to Be Cautious",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_76fd04d6177fa7e4": {
+    "title": "A Word on Machine Ethics: A Response to Jiang et al. (2021)",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2d0f8fbf5aa49155": {
+    "title": "Efficient estimates of optimal transport via low-dimensional embeddings",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6c313d37e8b148d6": {
+    "title": "Lymph Node Detection in T2 MRI with Transformers",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_542736ebb8aad1d0": {
+    "title": "Explainable AI (XAI): A Systematic Meta-Survey of Current Challenges and Future Opportunities",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_464de48531ae3c80": {
+    "title": "Improving Learning from Demonstrations by Learning from Experience",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_315b5d43a0d58bb6": {
+    "title": "Software Engineering for Responsible AI: An Empirical Study and Operationalised Patterns",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_da0cfd50754b6180": {
+    "title": "Finding Useful Predictions by Meta-gradient Descent to Improve Decision-making",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_7e373da22bc9542a": {
+    "title": "Machines & Influence: An Information Systems Lens",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_118b4f6716338f5b": {
+    "title": "Learning from learning machines: a new generation of AI technology to meet the needs of science",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9f93c053bb136fda": {
+    "title": "Weighing the Milky Way and Andromeda with Artificial Intelligence",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9c44e9033875db80": {
+    "title": "AI and the Everything in the Whole Wide World Benchmark",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0a76ecf713853808": {
+    "title": "MESA: Offline Meta-RL for Safe Adaptation and Fault Tolerance",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f9b16944b77e75a3": {
+    "title": "Filling gaps in trustworthy development of AI",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_226dad31be434c16": {
+    "title": "Programmatic Reward Design by Example",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7c7c5101e999d894": {
+    "title": "WebGPT: Browser-assisted question-answering with human feedback",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_aa42112787cbc414": {
+    "title": "Demanding and Designing Aligned Cognitive Architectures",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3983b42c3f367b5a": {
+    "title": "Modeling Human-AI Team Decision Making",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_aee49bba8b9aac67": {
+    "title": "The Turing Trap: The Promise & Peril of Human-Like Artificial Intelligence",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_56829389fad04d54": {
+    "title": "The Concept of Criticality in AI Safety",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_85f393e0d24a929a": {
+    "title": "Tools and Practices for Responsible AI Engineering",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e086e270e0fa1cda": {
+    "title": "Measuring Non-Probabilistic Uncertainty: A cognitive, logical and computational assessment of known and unknown unknowns",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b229b98591d4895d": {
+    "title": "Planning Not to Talk: Multiagent Systems that are Robust to Communication Loss",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ee653d87f7edfc97": {
+    "title": "Improving Behavioural Cloning with Human-Driven Dynamic Dataset Augmentation",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2cc6d95d810cf3d7": {
+    "title": "Safety-Aware Multi-Agent Apprenticeship Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_54fce49dfd17b9cf": {
+    "title": "Priors, Hierarchy, and Information Asymmetry for Skill Transfer in Reinforcement Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0e530f67c0d52910": {
+    "title": "Scaling Up Knowledge Graph Creation to Large and Heterogeneous Data Sources",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_813db9ba4098d5fb": {
+    "title": "Safe AI -- How is this Possible?",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_aa8c44de8cf70353": {
+    "title": "Cybertrust: From Explainable to Actionable and Interpretable AI (AI2)",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8726f32562cff5eb": {
+    "title": "Human-centered mechanism design with Democratic AI",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_41880a502afdcb9f": {
+    "title": "Explaining Reinforcement Learning Policies through Counterfactual Trajectories",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d2fb125a5bdcf1e2": {
+    "title": "CIC: Contrastive Intrinsic Control for Unsupervised Skill Discovery",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ca70467cf934e8af": {
+    "title": "Technology Ethics in Action: Critical and Interdisciplinary Perspectives",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_62776f407519f655": {
+    "title": "Solving Dynamic Principal-Agent Problems with a Rationally Inattentive Principal",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_837f414b898df869": {
+    "title": "Human rights, democracy, and the rule of law assurance framework for AI systems: A proposal",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1aef4c64a68bc52e": {
+    "title": "The 6-Ds of Creating AI-Enabled Systems",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_407a89d50dd6ff35": {
+    "title": "Knowledge-Integrated Informed AI for National Security",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_97a6e556f7ea88f7": {
+    "title": "Reward is not enough: can we liberate AI from the reinforcement learning paradigm?",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_36215638a79b3cec": {
+    "title": "Local Explanations for Reinforcement Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0b8e091c821c1248": {
+    "title": "Machine Explanations and Human Understanding",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a9e748f28cffc103": {
+    "title": "Interpretable pipelines with evolutionarily optimized modules for RL tasks with visual inputs",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7d71464129d360de": {
+    "title": "Trust in AI: Interpretability is not necessary or sufficient, while black-box interaction is necessary and sufficient",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cad61abb903ac95e": {
+    "title": "Uncalibrated Models Can Improve Human-AI Collaboration",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4ede69fce8724f7a": {
+    "title": "Zero-Shot Assistance in Sequential Decision Problems",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cc61b8282355a971": {
+    "title": "Critical Checkpoints for Evaluating Defence Models Against Adversarial Attack and Robustness",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c9041a9f9410d0e0": {
+    "title": "HCMD-zero: Learning Value Aligned Mechanisms from Data",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_68da4ab0079db520": {
+    "title": "Investigations of Performance and Bias in Human-AI Teamwork in Hiring",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a330fb6324994e69": {
+    "title": "Composing Complex and Hybrid AI Solutions",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8fc7eef981a673d2": {
+    "title": "OCR-IDL: OCR Annotations for Industry Document Library Dataset",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ff56b064384bb82c": {
+    "title": "The dangers in algorithms learning humans' values and irrationalities",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c65b99f477ddc2a6": {
+    "title": "Responsible-AI-by-Design: a Pattern Collection for Designing Responsible AI Systems",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_205e847060cffe58": {
+    "title": "Reasoning about Counterfactuals to Improve Human Inverse Reinforcement Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_71955245b24a9957": {
+    "title": "Graph Neural Networks for Multimodal Single-Cell Data Integration",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_12ae1fc6cb0a054e": {
+    "title": "A Typology for Exploring the Mitigation of Shortcut Behavior",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_411295d672508f93": {
+    "title": "Algebraic Learning: Towards Interpretable Information Modeling",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c52390c5cf7e651a": {
+    "title": "CMKD: CNN/Transformer-Based Cross-Model Knowledge Distillation for Audio Classification",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f8f35509051016e1": {
+    "title": "Building AI Innovation Labs together with Companies",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d1469829e90fd39d": {
+    "title": "Towards a Roadmap on Software Engineering for Responsible AI",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f0c30e26a6a5c846": {
+    "title": "Robust Action Gap Increasing with Clipped Advantage Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f0761751cbd78c67": {
+    "title": "A Rationale-Centric Framework for Human-in-the-loop Machine Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_038cf60b42288177": {
+    "title": "Quality Assurance of Generative Dialog Models in an Evolving Conversational Agent Used for Swedish Language Practice",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e194d39761efb0bc": {
+    "title": "Graph-in-Graph (GiG): Learning interpretable latent graphs in non-Euclidean domain for biological and healthcare applications",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4b80438954bd57fd": {
+    "title": "Robust Event-Driven Interactions in Cooperative Multi-Agent Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c86d638a79093201": {
+    "title": "Enhancing the Robustness, Efficiency, and Diversity of Differentiable Architecture Search",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_827b75911b8bf55a": {
+    "title": "Linguistic communication as (inverse) reward design",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_da59e3fffc6d024a": {
+    "title": "Metaethical Perspectives on 'Benchmarking' AI Ethics",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fa94eb811e4ed6f4": {
+    "title": "Flexible Multiple-Objective Reinforcement Learning for Chip Placement",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_81d6196790eb7f2f": {
+    "title": "Contextualizing Artificially Intelligent Morality: A Meta-Ethnography of Top-Down, Bottom-Up, and Hybrid Models for Theoretical and Applied Ethics in Artificial Intelligence",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1aa18a5cdb5e7320": {
+    "title": "The Risks of Machine Learning Systems",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d66efe89f7edc9c7": {
+    "title": "Path-Specific Objectives for Safer Agent Incentives",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_568da857b5fce82c": {
+    "title": "A Survey on XAI for Beyond 5G Security: Technical Aspects, Use Cases, Challenges and Research Directions",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_37c071c07d3ab37d": {
+    "title": "A Deep Reinforcement Learning Framework for Rapid Diagnosis of Whole Slide Pathological Images",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_398f8d39b2bd93d7": {
+    "title": "The AI Index 2022 Annual Report",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2034930e8b818514": {
+    "title": "A Survey on AI Sustainability: Emerging Trends on Learning Algorithms and Research Challenges",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f92a4eb8634567a0": {
+    "title": "Aligned with Whom? Direct and social goals for AI systems",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2f05d4ecf6a6e80f": {
+    "title": "How Different Groups Prioritize Ethical Values for Responsible AI",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8fb6f61cf1e07a5b": {
+    "title": "Mimicking Behaviors in Separated Domains",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1dbd17639184d9aa": {
+    "title": "Exploring the Trade-off between Plausibility, Change Intensity and Adversarial Power in Counterfactual Explanations using Multi-objective Optimization",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0530e7dcfd24a85d": {
+    "title": "Responsible Artificial Intelligence -- from Principles to Practice",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_3d1babdf4c394570": {
+    "title": "A Human-Centric Assessment Framework for AI",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c3fe4405e8d21673": {
+    "title": "GALOIS: Boosting Deep Reinforcement Learning via Generalizable Logic Synthesis",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d9ef3d1c33508753": {
+    "title": "Personalized Algorithmic Recourse with Preference Elicitation",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e0f20ce2810fbb03": {
+    "title": "Multi-Game Decision Transformers",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cc24dc9a94859490": {
+    "title": "HYCEDIS: HYbrid Confidence Engine for Deep Document Intelligence System",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bce64cd381cfaef8": {
+    "title": "Improving Model Understanding and Trust with Counterfactual Explanations of Model Confidence",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_08f6fc9e4b21ce87": {
+    "title": "CAISAR: A platform for Characterizing Artificial Intelligence Safety and Robustness",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_87cef25502a7208a": {
+    "title": "Towards Safe Reinforcement Learning via Constraining Conditional Value-at-Risk",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_996788ee14c025d6": {
+    "title": "Towards Autonomous Grading In The Real World",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bf30366d2c838523": {
+    "title": "Characteristics of Harmful Text: Towards Rigorous Benchmarking of Language Models",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e7aa7614cdd5882a": {
+    "title": "Modeling Transformative AI Risks (MTAIR) Project -- Summary Report",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_24824a8aca1cb4f1": {
+    "title": "Uncertainty Quantification for Competency Assessment of Autonomous Agents",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_12d4b77ba8206503": {
+    "title": "Formalizing the Problem of Side Effect Regularization",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_40b8cefc2fc84f5a": {
+    "title": "On Avoiding Power-Seeking by Artificial Intelligence",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e2f6a639eab01084": {
+    "title": "Multi-Modal and Multi-Factor Branching Time Active Inference",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5f679aa5f67a93ba": {
+    "title": "Parametrically Retargetable Decision-Makers Tend To Seek Power",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fc8a8d2a6ce0ac6b": {
+    "title": "Auditing Visualizations: Transparency Methods Struggle to Detect Anomalous Behavior",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_72206017b1892b4e": {
+    "title": "The Linguistic Blind Spot of Value-Aligned Agency, Natural and Artificial",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b53638f9eff11ba5": {
+    "title": "Inferring and Conveying Intentionality: Beyond Numerical Rewards to Logical Intentions",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_a15c6ca117433170": {
+    "title": "Boolean Decision Rules for Reinforcement Learning Policy Summarisation",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_a20e7aa50600de9a": {
+    "title": "The Need for a Meta-Architecture for Robot Autonomy",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_16071e9e4803e5d3": {
+    "title": "Discriminator-Weighted Offline Imitation Learning from Suboptimal Demonstrations",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3673d000a2f561d4": {
+    "title": "Toward Supporting Perceptual Complementarity in Human-AI Collaboration via Reflection on Unobservables",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_813257bd6020c643": {
+    "title": "Latent Properties of Lifelong Learning Systems",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_4ae4bd88689053a3": {
+    "title": "The History of AI Rights Research",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6b2e6017f5a03ddc": {
+    "title": "Recognition of All Categories of Entities by AI",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1cb7117de1a9757a": {
+    "title": "A Review of the Convergence of 5G/6G Architecture and Deep Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cada59fae9928dc6": {
+    "title": "Discovering Agents",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ade5f50f2414624d": {
+    "title": "Information-Theoretic Equivalence of Entropic Multi-Marginal Optimal Transport: A Theory for Multi-Agent Communication",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_41f01220cbd1248e": {
+    "title": "The Brussels Effect and Artificial Intelligence: How EU regulation will impact the global AI market",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_49fd4c87928829fe": {
+    "title": "Reinforcement Learning for Hardware Security: Opportunities, Developments, and Challenges",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_013103aafe00cc7c": {
+    "title": "Correct-by-Construction Runtime Enforcement in AI -- A Survey",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a52d7e463ed25117": {
+    "title": "A Technique to Create Weaker Abstract Board Game Agents via Reinforcement Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_eb041408df75f83a": {
+    "title": "Improving Language Model Prompting in Support of Semi-autonomous Task Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8bd5e5d8b24864fd": {
+    "title": "The BLue Amazon Brain (BLAB): A Modular Architecture of Services about the Brazilian Maritime Territory",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b9f4aa2968038b7d": {
+    "title": "LCRL: Certified Policy Synthesis via Logically-Constrained Reinforcement Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_df249401a5807eac": {
+    "title": "Understanding Hindsight Goal Relabeling from a Divergence Minimization Perspective",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ab6a3d0259d74218": {
+    "title": "Learning When to Advise Human Decision Makers",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_81938f6faa998c07": {
+    "title": "Repairing Bugs in Python Assignments Using Large Language Models",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1ba9a6fd67dca3f8": {
+    "title": "Quantifying Harm",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d89dc844516a9ac0": {
+    "title": "Establishing Meta-Decision-Making for AI: An Ontology of Relevance, Representation and Reasoning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_96251f8fa8c416e4": {
+    "title": "Knowledge-Grounded Reinforcement Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_819170fb22a3fc27": {
+    "title": "Generating Executable Action Plans with Environmentally-Aware Language Models",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7d0c1226cf8dfc6c": {
+    "title": "Human-AI Coordination via Human-Regularized Search and Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0a40d2de6851709b": {
+    "title": "Toward Next-Generation Artificial Intelligence: Catalyzing the NeuroAI Revolution",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_51462a55534263d1": {
+    "title": "A.I. Robustness: a Human-Centered Perspective on Technological Challenges and Opportunities",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_40adcd148ad64c63": {
+    "title": "Gathering Strength, Gathering Storms: The One Hundred Year Study on Artificial Intelligence (AI100) 2021 Study Panel Report",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_311e5bef699a0916": {
+    "title": "Relative Behavioral Attributes: Filling the Gap between Symbolic Goal Specification and Reward Learning from Human Preferences",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ae1cd229c3a155b3": {
+    "title": "Liability regimes in the age of AI: a use-case driven analysis of the burden of proof",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c0390431ab3a215a": {
+    "title": "Examining the Differential Risk from High-level Artificial Intelligence and the Question of Control",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_dfc4726f702c6b41": {
+    "title": "Verifiable Reinforcement Learning via Policy Extraction",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2d77f5b7adcea3e2": {
+    "title": "To Trust Or Not To Trust A Classifier",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7d06b53a7df5e114": {
+    "title": "Relational inductive biases, deep learning, and graph networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f1853376f2ccc7f0": {
+    "title": "Relational Deep Reinforcement Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_583c6e401e206e40": {
+    "title": "Benchmarking Neural Network Robustness to Common Corruptions and Surface Variations",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bfaa915ab1de8d52": {
+    "title": "Deep Learning in the Wild",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b6618e5296fd0bba": {
+    "title": "Learning Plannable Representations with Causal InfoGAN",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8ef5690345b73a74": {
+    "title": "Learning Actionable Representations from Visual Observations",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_490dfc6810f0f52e": {
+    "title": "Adversarial Vision Challenge",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e1689a1cb524a05d": {
+    "title": "Cycle-of-Learning for Autonomous Systems from Human Interaction",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_84fc757d197d496d": {
+    "title": "Neural Guided Constraint Logic Programming for Program Synthesis",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4aede7012db72353": {
+    "title": "Training for Faster Adversarial Robustness Verification via Inducing ReLU Stability",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a0402d3a00d97e1e": {
+    "title": "Episodic Curiosity through Reachability",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7cfec0e7f7a0495a": {
+    "title": "Meta-Learning: A Survey",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5d8d41b153d13a07": {
+    "title": "CURIOUS: Intrinsically Motivated Modular Multi-Goal Reinforcement Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0ebf56aabf1e884f": {
+    "title": "Assessing Generalization in Deep Reinforcement Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7a4d122a4cd52098": {
+    "title": "Woulda, Coulda, Shoulda: Counterfactually-Guided Policy Search",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_12c150d8843037cc": {
+    "title": "Off-Policy Deep Reinforcement Learning without Exploration",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a444c76549f57bb1": {
+    "title": "Paired Open-Ended Trailblazer (POET): Endlessly Generating Increasingly Complex and Diverse Learning Environments and Their Solutions",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5089b9ff46e9fa8a": {
+    "title": "Risk-Aware Active Inverse Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f95f04b04ff7a4b1": {
+    "title": "The Hanabi Challenge: A New Frontier for AI Research",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1f18fc5bb4cfac98": {
+    "title": "From Language to Goals: Inverse Reinforcement Learning for Vision-Based Instruction Following",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7aa7add91c4d9bde": {
+    "title": "Diagnosing Bottlenecks in Deep Q-learning Algorithms",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fc1f4ca4b9f0f52f": {
+    "title": "SLIDE : In Defense of Smart Algorithms over Hardware Acceleration for Large-Scale Deep Learning Systems",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1971dfd835458fc8": {
+    "title": "A Survey of Reinforcement Learning Informed by Natural Language",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_29912d5e770917b0": {
+    "title": "On Inductive Biases in Deep Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9588974df808d2b1": {
+    "title": "Improving Sample Efficiency in Model-Free Reinforcement Learning from Images",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_28785e694de9fb37": {
+    "title": "Integrating Behavior Cloning and Reinforcement Learning for Improved Performance in Dense and Sparse Reward Environments",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c1201a83d177fa63": {
+    "title": "Stabilizing Transformers for Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_77f8c55109ae4cb3": {
+    "title": "Planning with Goal-Conditioned Policies",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_aff90061d03fe488": {
+    "title": "Dream to Control: Learning Behaviors by Latent Imagination",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_50f785472f9f9817": {
+    "title": "Deep Bayesian Reward Learning from Preferences",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2d5fd096432bd8b9": {
+    "title": "What Can Learned Intrinsic Rewards Capture?",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7010710588ce3649": {
+    "title": "A high-precision abundance analysis of the nuclear benchmark star HD 20",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e918941f9bdc2140": {
+    "title": "State-only Imitation with Transition Dynamics Mismatch",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f3b2634f69a529a4": {
+    "title": "On Catastrophic Interference in Atari 2600 Games",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_67acbfb8e5ef7365": {
+    "title": "\"Other-Play\" for Zero-Shot Coordination",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_14ff96fd6948a4bf": {
+    "title": "Curriculum Learning for Reinforcement Learning Domains: A Framework and Survey",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_17f6f61338a0d2b0": {
+    "title": "Constrained Policy Optimization",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0f2df22712848c03": {
+    "title": "Verification of Non-Linear Specifications for Neural Networks",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f18e14f67088d23c": {
+    "title": "Adversarial Robustness through Local Linearization",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0e44e17c3879b667": {
+    "title": "Fine-Tuning Language Models from Human Preferences",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_20004f3f3339a4fd": {
+    "title": "Active Reinforcement Learning: Observing Rewards at a Cost",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b29568681c7d3227": {
+    "title": "An Overview of Catastrophic AI Risks",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_93539db90a16dfab": {
+    "title": "TASRA: a Taxonomy and Analysis of Societal-Scale Risks from AI",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6fecf371e716d4a0": {
+    "title": "Interpretability in the Wild: a Circuit for Indirect Object Identification in GPT-2 small",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6b434c3af993d14b": {
+    "title": "Polysemanticity and Capacity in Neural Networks",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_aed15d8ec6db81a2": {
+    "title": "Adversarial Training for High-Stakes Reliability",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6252189f483ff7ff": {
+    "title": "X-Risk Analysis for AI Research.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a112033c840b0762": {
+    "title": "Actionable Guidance for High-Consequence AI Risk Management: Towards Standards Addressing AI Catastrophic Risks.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f1cf4d6f754ad5fe": {
+    "title": "Sociotechnical Specification for the Broader Impacts of Autonomous Vehicles.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c0a91469fb17f17e": {
+    "title": "Towards more Generalizable One-shot Visual Imitation Learning.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_39c7fd0f423aa003": {
+    "title": "Building Human Values into Recommender Systems: An Interdisciplinary Synthesis.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_455b444cf51f7bbd": {
+    "title": "How Would The Viewer Feel? Estimating Wellbeing From Video Scenarios.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0f2f1b0c49e94345": {
+    "title": "Inferring Rewards from Language in Context.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9ad41374f53f74d9": {
+    "title": "Estimating and Penalizing Induced Preference Shifts in Recommender Systems.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4bcb6e5e5420699a": {
+    "title": "Skill Preferences: Learning to Extract and Execute Robotic Skills from Human Feedback.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_92cde803b8cb2b1d": {
+    "title": "Optimal Cost Design for Model Predictive Control.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5585b20ff1241af9": {
+    "title": "Cross-Domain Imitation Learning via Optimal Transport.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_dece29c717e85054": {
+    "title": "The MAGICAL Benchmark for Robust Imitation.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7b1fcae71ae04aa5": {
+    "title": "Interpretable and Pedagogical Examples.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5e6dd6e10068aa22": {
+    "title": "Understanding Learned Reward Functions.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1e952d5dd2d90caf": {
+    "title": "DERAIL: Diagnostic Environments for Reward And Imitation Learning.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_673f5a66b8253c07": {
+    "title": "Choice Set Misspecification in Reward Inference.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1405aec1edf8be7e": {
+    "title": "Quantifying Hypothesis Space Misspecification in Learning from Human-Robot Demonstrations and Physical Corrections.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_117d259472867be5": {
+    "title": "Hierarchically Decoupled Imitation for Morphological Transfer.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d5d871f8c38b8423": {
+    "title": "Using Machine Learning to Guide Cognitive Modeling: A Case Study in Moral Reasoning.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e442648d2f9714c2": {
+    "title": "Social Cohesion in Autonomous Driving.",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_858b9038e0a18fff": {
+    "title": "Repeated Inverse Reinforcement Learning.",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f78c7ec5be74c3e3": {
+    "title": "Learning Representations that Enable Generalization in Assistive Tasks.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a42af15d067364d3": {
+    "title": "Safety Assurances for Human-Robot Interaction via Confidence-aware Game-theoretic Human Models.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fda9554f87844fc3": {
+    "title": "Fleet-DAgger: Interactive Robot Fleet Learning with Scalable Human Supervision.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_dfe8653b4e582909": {
+    "title": "Hierarchical Few-Shot Imitation with Skill Transition Models.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4383a47169e01d45": {
+    "title": "Learning Visuo-Haptic Skewering Strategies for Robot-Assisted Feeding.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2645dbafdafd63d5": {
+    "title": "Balancing Efficiency and Comfort in Robot-Assisted Bite Transfer.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f9f624688935e74f": {
+    "title": "Learning from Imperfect Demonstrations via Adversarial Confidence Transfer.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ad62fda39f25ed18": {
+    "title": "Learning Latent Actions to Control Assistive Robots.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_590c3520e8afde51": {
+    "title": "Optimal Behavior Prior: Improving Human-AI Collaboration Through Generalizable Human Models..",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_07c0229080ab2399": {
+    "title": "JEDAI: A System for Skill-Aligned Explainable Robot Planning.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_37dde144c26b9e56": {
+    "title": "Joint Communication and Motion Planning for Cobots.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7dd0fe90b65c5210": {
+    "title": "Pragmatic Image Compression for Human-in-the-Loop Decision-Making.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b208fd79f647fe24": {
+    "title": "On complementing end-to-end human behavior predictors with planning.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e27044932d54ad26": {
+    "title": "Analyzing Human Models that Adapt Online.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_173c85a03b5009b4": {
+    "title": "Dynamically Switching Human Prediction Models for Efficient Planning.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_66b00ffd67710860": {
+    "title": "Multi-Principal Assistance Games.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_232f0e18dbb9e722": {
+    "title": "Courteous Autonomous Cars.",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7065ba6b881fd64f": {
+    "title": "Do You Want Your Autonomous Car to Drive Like You?.",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f2ac3447dea6aeca": {
+    "title": "Generating Plans that Predict Themselves.",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c9abd238dd2b341d": {
+    "title": "It Takes Four to Tango: Multiagent Self Play for Automatic Curriculum Generation.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2d9e86d8bb50bdb3": {
+    "title": "PantheonRL: A MARL Library for Dynamic Training Interactions.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_a11519be70a65610": {
+    "title": "COLA: Consistent Learning with Opponent-Learning Awareness.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_030d3ea251808602": {
+    "title": "Similarity-based Cooperation.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a24b6a306ac63ccf": {
+    "title": "No?regret Learning in Dynamic Stackelberg Games.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8b6e99864384b269": {
+    "title": "Generalizing meanings from partners to populations: Hierarchical inference supports convention formation on networks.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8606d4d1cec21bda": {
+    "title": "Implementing Mediators with Asynchronous Cheap Talk.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_21f2bad360e8a7d2": {
+    "title": "Self-confirming price-prediction strategies for simultaneous one-shot auctions.",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0e8afc013c84e4e7": {
+    "title": "Causality, Responsibility and Blame in Team Plans.",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9f4e3db3a06a3c14": {
+    "title": "Dynamic Awareness.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c6e1d26604cebcd7": {
+    "title": "AMP: Adversarial Motion Priors for Stylized Physics-Based Character Control.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_21a3c572c5611388": {
+    "title": "Perceptual Adversarial Robustness: Defense Against Unseen Threat Models.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a5042b5aab956d77": {
+    "title": "Adversarial Training with Voronoi Constraints.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0fdf5b2c39518e9d": {
+    "title": "Natural Adversarial Examples.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_810e39a469917c9d": {
+    "title": "Pretraining Graph Neural Networks for few-shot Analog Circuit Modeling and Design.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e5379b568f77d362": {
+    "title": "Sim-to-Real via Sim-to-Seg: End-to-end Off-road Autonomous Driving Without Real Data.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fae603fcbb9051d8": {
+    "title": "DayDreamer: World Models for Physical Robot Learning.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5b8bd5bb5035743d": {
+    "title": "Director: Deep Hierarchical Planning from Pixels.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_da793a00734aa3aa": {
+    "title": "Learning Visual Robotic Control Efficiently with Contrastive Pre-training and Data Augmentation.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_19783db6de007b65": {
+    "title": "Language Models as Zero-Shot Planners: Extracting Actionable Knowledge for Embodied Agents.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1670e43adbfe4218": {
+    "title": "Zero-Shot Text-Guided Object Generation with Dream Fields,.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bde187870c058fb9": {
+    "title": "Weakly Supervised Correspondence Learning.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9a865c22fd02cd19": {
+    "title": "Automatic Correction of Human Translations.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f73ccdf3c4176eb4": {
+    "title": "Path Independent Equilibrium Models Can Better Exploit Test-Time Computation.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_75e887cfeec8a3e0": {
+    "title": "Learning Deterministic Finite Automata Decompositions from Examples and Demonstrations.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1118b36d97a0748c": {
+    "title": "Measuring mathematical problem solving with the math dataset.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a262d9743e00d855": {
+    "title": "Behavior From the Void: Unsupervised Active Pre-Training.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_641ff6dee15b77cf": {
+    "title": "State Entropy Maximization with Random Encoders for Efficient Exploration.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_13e9b257e46a7316": {
+    "title": "Unsupervised Learning of Visual 3D Keypoints for Control.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_eaf0dda90bdb58bc": {
+    "title": "Contrastive Code Representation Learning.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_82d12f25322fcc11": {
+    "title": "Offline-to-Online Reinforcement Learning via Balanced Replay and Pessimistic Q-Ensemble.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fe1c58202b218fa6": {
+    "title": "Improving Computational Efficiency in Visual Reinforcement Learning via Stored Embeddings.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_40981833e4aac1ab": {
+    "title": "URLB: Unsupervised Reinforcement Learning Benchmark.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2ddfc52c8f61abd0": {
+    "title": "Learning State Representations from Random Deep Action-Conditional Predictions.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_686b8ae940e6d772": {
+    "title": "Agent-aware state estimation for autonomous vehicles.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5c91e99695035a96": {
+    "title": "Measuring Massive Multitask Language Understanding.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a3b00e2c7467d45b": {
+    "title": "Emergent Complexity and Zero-shot Transfer via Unsupervised Environment Design.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a99ca4e2ecd6377e": {
+    "title": "Sparse Graphical Memory for Robust Planning.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6af2c5740e297388": {
+    "title": "Using Natural Language and Program Abstractions to Instill Human Inductive Biases in Machines..",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2294e451ea1f1e52": {
+    "title": "Disentangling Abstraction from Statistical Pattern Matching in Human and Machine Learning..",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f60dc3ec42354be6": {
+    "title": "Reinforcement Learning of Implicit and Explicit Control Flow Instructions.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_568f000a038e4bfb": {
+    "title": "Passive Attention in Artificial Neural Networks Predicts Human Visual Selectivity.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c81baef1bf42629d": {
+    "title": "Scaling up psychology via Scientific Regret Minimization.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d633e3343d2a7ddf": {
+    "title": "Value-laden Disciplinary Shifts in Machine Learning.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_56c4bb5d101fa24c": {
+    "title": "Aligning AI With Shared Human Values.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2315ba0ad7702ea8": {
+    "title": "A Broader View on Bias in Automated Decision-Making: Reflecting on Epistemology and Dynamics.",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_f4a05e444ea709d5": {
+    "title": "Multi-Objective Policy Gradients with Topological Constraints.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3df04342ed5b89b2": {
+    "title": "A Unified Survey on Anomaly, Novelty, Open-Set, and Out-of-Distribution Detection: Solutions and Future Challenges.",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ab8ad7fbfc76f44a": {
+    "title": "Policy Gradient Bayesian Robust Optimization for Imitation Learning.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2715c5be751ae5c0": {
+    "title": "The Many Faces of Robustness: A Critical Analysis of Out-of-Distribution Generalization.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8cd0e4f9e43b214e": {
+    "title": "Pretrained Transformers Improve Out-of-Distribution Robustness.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_db5b97196116c843": {
+    "title": "AugMix: A Simple Data Processing Method to Improve Robustness and Uncertainty.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1381c91c59063974": {
+    "title": "Bayesian Robustness: A Nonasymptotic Viewpoint.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f84b0a1d30cf89ae": {
+    "title": "A Risk-Sensitive Finite-Time Reachability Approach for Safety of Stochastic Dynamic Systems.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1c1b01ae4d1233f4": {
+    "title": "Using Self-Supervised Learning Can Improve Model Robustness and Uncertainty.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3d6bfae31f2f8bec": {
+    "title": "Benchmarking Neural Network Robustness to Common Corruptions and Perturbations.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3f4254f317701007": {
+    "title": "Deep Anomaly Detection with Outlier Exposure.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f3749553512e1b66": {
+    "title": "Using Trusted Data to Train Deep Networks on Labels Corrupted by Severe Noise.",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7902a1192772be3d": {
+    "title": "Differential Assessment of Black-Box AI Agents..",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_73592b70a3f5a792": {
+    "title": "Translating Neuralese.",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_838c66e61a6f18fb": {
+    "title": "Towards Deep Learning Models Resistant to Adversarial Attacks",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_eb789c40c7c9d84c": {
+    "title": "Adversarial Examples Are a Natural Consequence of Test Error in Noise",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_81cbec0f7ca3bf7e": {
+    "title": "Motivating the Rules of the Game for Adversarial Example Research",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b3ec07e1af2d6ccb": {
+    "title": "Certified Defenses against Adversarial Examples",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8b5c292409e3da52": {
+    "title": "ImageNet-trained CNNs are biased towards texture; increasing shape bias improves accuracy and robustness",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f3b63431438b60d2": {
+    "title": "On Calibration of Modern Neural Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c356f4bb1fc1101d": {
+    "title": "TruthfulQA: Measuring How Models Mimic Human Falsehoods",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_dc43714b96ecfc2b": {
+    "title": "Truthful AI: Developing and governing AI that does not lie",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8b4d803b67aaf3b9": {
+    "title": "Avoiding Side Effects in Complex Environments",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bf0ff25d784f6380": {
+    "title": "Open Problems in Cooperative AI",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1a828311da6c652e": {
+    "title": "Unsolved Problems in ML Safety.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ec060a99eb4e8e9a": {
+    "title": "Designing Recommender Systems to Depolarize.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d515617e558a6b73": {
+    "title": "Feature Expansive Reward Learning: Rethinking Human Input.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9c2fbcdfc8dd0ae5": {
+    "title": "Conservative agency via attainable utility preservation..",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_399d1e79027dcec2": {
+    "title": "LESS is More: Rethinking Probabilistic Models of Human Behavior.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bea3a247e8e516c2": {
+    "title": "Incomplete Contracting and AI Alignment.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a8f634af414f0b09": {
+    "title": "Legible Normativity for AI Alignment: The Value of Silly Rules.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_44744bf31057f3d2": {
+    "title": "Reward-rational (implicit) choice: A unifying formalism for reward learning.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_961c51700a43ebc0": {
+    "title": "Literal or Pedagogic Human? Analyzing Human Model Misspecification in Objective Learning.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c4281a21a93e37ca": {
+    "title": "Active Inverse Reward Design.",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4b13c4aa7548bc21": {
+    "title": "Inverse Reward Design.",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1e1f88201aaae570": {
+    "title": "On the Utility of Model Learning in HRI.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_23e75d98b422f570": {
+    "title": "Adversarial Policies: Attacking Deep Reinforcement Learning.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5ab3b57cc0401a5d": {
+    "title": "On the Geometry of Adversarial Examples.",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4f277b537530f3d0": {
+    "title": "Decision Transformer: Reinforcement Learning via Sequence Modeling.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_915a21392784fa54": {
+    "title": "Measuring Coding Challenge Competence With APPS.",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_980dbd86b111912d": {
+    "title": "Hard Choices in Artificial Intelligence: Addressing Normative Uncertainty through Sociotechnical Commitments.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fe0dc44c3e878801": {
+    "title": "Building Machines That Learn and Think Like People",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_53bbe9ae329b1987": {
+    "title": "Avoiding Negative Side Effects due to Incomplete Knowledge of AI Systems",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4d20560a864f229f": {
+    "title": "Towards A Rigorous Science of Interpretable Machine Learning",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_846a5ff7a4b4af28": {
+    "title": "Evaluating Robustness of Neural Networks with Mixed Integer Programming",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_12e5756a832c2c9c": {
+    "title": "First-order Adversarial Vulnerability of Neural Networks and Input Dimension",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_82e11ba0203ce145": {
+    "title": "Manipulating and Measuring Model Interpretability",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fa2dc7d0bf954de3": {
+    "title": "Autonomous Intelligent Cyber-defense Agent (AICA) Reference Architecture. Release 2.0",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_125feae2ca4bf463": {
+    "title": "Adversarial Attacks and Defences Competition",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_54c4066155dbf604": {
+    "title": "Universal Planning Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8712b809a4aca35e": {
+    "title": "No Metrics Are Perfect: Adversarial Reward Learning for Visual Storytelling",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_57723e6c17d3c7a5": {
+    "title": "Reward Learning from Narrated Demonstrations",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1dd6134f73afc290": {
+    "title": "Imitating Latent Policies from Observation",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ab9d8313ec8c9ad6": {
+    "title": "A Psychopathological Approach to Safety Engineering in AI and AGI",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_741d13de2d731c54": {
+    "title": "Penalizing side effects using stepwise relative reachability",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5a0f56ad4bbd83a5": {
+    "title": "Learning Existing Social Conventions via Observationally Augmented Self-Play",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9e60622ab79fb17b": {
+    "title": "Representation Learning with Contrastive Predictive Coding",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5b7385484d3a48ca": {
+    "title": "Model-Based Reinforcement Learning via Meta-Policy Optimization",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c67c4f1f99a3acf3": {
+    "title": "BabyAI: A Platform to Study the Sample Efficiency of Grounded Language Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a836978dfbfc5b75": {
+    "title": "Integrative Biological Simulation, Neuropsychology, and AI Safety",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_6f54b171cfee650e": {
+    "title": "Reward learning from human preferences and demonstrations in Atari",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2409da6d09cd4302": {
+    "title": "Robustness via curvature regularization, and vice versa",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7bac61f7244aa0e9": {
+    "title": "Rigorous Agent Evaluation: An Adversarial Approach to Uncover Catastrophic Failures",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a6c16cdd16ab2351": {
+    "title": "Scaling shared model governance via model splitting",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0f27b954a6dd7471": {
+    "title": "Impossibility and Uncertainty Theorems in AI Value Alignment (or why your AGI should not have a utility function)",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e8d31791732b0a20": {
+    "title": "Algorithms for Verifying Deep Neural Networks",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4fa22ceddc8532fa": {
+    "title": "Towards Characterizing Divergence in Deep Q-Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_693565496a05778f": {
+    "title": "The LogBarrier adversarial attack: making effective use of decision boundary information",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_499a4638a0e2f313": {
+    "title": "Finding and Visualizing Weaknesses of Deep Reinforcement Learning Agents",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3f7138172c933108": {
+    "title": "Extrapolating Beyond Suboptimal Demonstrations via Inverse Reinforcement Learning from Observations",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f08658e9cc2aba17": {
+    "title": "HARK Side of Deep Learning -- From Grad Student Descent to Automated Machine Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_153bcb3b49c0c598": {
+    "title": "Challenges of Real-World Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e662dd63bdddd44f": {
+    "title": "PRECOG: PREdiction Conditioned On Goals in Visual Multi-Agent Settings",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0dbfdba362459a9e": {
+    "title": "Meta-learners' learning dynamics are unlike learners'",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a8e7867b6a274601": {
+    "title": "Meta-learning of Sequential Strategies",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_21e5965ab022e732": {
+    "title": "On Variational Bounds of Mutual Information",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_30993e4d225c1820": {
+    "title": "Cold Case: The Lost MNIST Digits",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c4f47b8ec83a65c4": {
+    "title": "AI-GAs: AI-generating algorithms, an alternate paradigm for producing general artificial intelligence",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_598d0f8ff5beacac": {
+    "title": "Causal Confusion in Imitation Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_79624763ad62f160": {
+    "title": "Learning Representations by Humans, for Humans",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_89cd3ef79c4ea526": {
+    "title": "Imitation Learning as $f$-Divergence Minimization",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_21e9aed4c6db2398": {
+    "title": "E-LPIPS: Robust Perceptual Image Similarity via Random Transformation Ensembles",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9037f853d10c9ac1": {
+    "title": "Modeling AGI Safety Frameworks with Causal Influence Diagrams",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_42153d4c6fb5d1f9": {
+    "title": "Towards Empathic Deep Q-Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0242bd9afee7aace": {
+    "title": "Norms for Beneficial A.I.: A Computational Analysis of the Societal Value Alignment Problem",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f86f78b8dda14fde": {
+    "title": "Better-than-Demonstrator Imitation Learning via Automatically-Ranked Demonstrations",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_782a1b8a0e048fa7": {
+    "title": "Is BERT Really Robust? A Strong Baseline for Natural Language Attack on Text Classification and Entailment",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_793b9faea6d52daf": {
+    "title": "Improving Deep Reinforcement Learning in Minecraft with Action Advice",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_64e368da441409b5": {
+    "title": "Finding Generalizable Evidence by Learning to Convince Q&A Models",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7ffcd3b363df9e5b": {
+    "title": "Scaling data-driven robotics with reward sketching and batch reinforcement learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cc87f82087030182": {
+    "title": "A Constructive Prediction of the Generalization Error Across Scales",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5b89337caf817fe3": {
+    "title": "Positive-Unlabeled Reward Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a338ff49276e0aa0": {
+    "title": "Self-training with Noisy Student improves ImageNet classification",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9cce57483fe0df92": {
+    "title": "The Transformative Potential of Artificial Intelligence",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_584641e15cc07415": {
+    "title": "Exploratory Not Explanatory: Counterfactual Analysis of Saliency Maps for Deep Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1eda22f5f61402fa": {
+    "title": "Regulatory Markets for AI Safety",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_dfe1a69ce0a50944": {
+    "title": "The Offense-Defense Balance of Scientific Knowledge: Does Publishing AI Research Reduce Misuse?",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_38b411043c9d563e": {
+    "title": "Social and Governance Implications of Improved Data Efficiency",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_30a2c9b450475104": {
+    "title": "Gradient Surgery for Multi-Task Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9e8530cde437a62a": {
+    "title": "Artificial Intelligence, Values and Alignment",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7add01516d3cbae1": {
+    "title": "Towards a Human-like Open-Domain Chatbot",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b26648e7d3c2e4a8": {
+    "title": "Towards Learning Multi-agent Negotiations via Self-Play",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_085c7909f407e916": {
+    "title": "AI safety: state of the field through quantitative lens",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e346718357f748f7": {
+    "title": "The Next Decade in AI: Four Steps Towards Robust Artificial Intelligence",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1bf0c3e8c1c8c32b": {
+    "title": "Learning to Continually Learn",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_559978de79b22f4e": {
+    "title": "Unsupervised Question Decomposition for Question Answering",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_aa8dbeb0c06350de": {
+    "title": "Neuron Shapley: Discovering the Responsible Neurons",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_26a97802b8567bca": {
+    "title": "Rethinking Bias-Variance Trade-off for Generalization of Neural Networks",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0a23eb6270740896": {
+    "title": "TuringAdvice: A Generative and Dynamic Evaluation of Language Use",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bbfdc27ddeb5e3a5": {
+    "title": "Dark, Beyond Deep: A Paradigm Shift to Cognitive AI with Humanlike Common Sense",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f0be2e561501caeb": {
+    "title": "Image Augmentation Is All You Need: Regularizing Deep Reinforcement Learning from Pixels",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_90c0cd83d6e802b5": {
+    "title": "Reinforcement Learning with Augmented Data",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9f33f3f44f3ec144": {
+    "title": "Learning to Complement Humans",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c2ab3aad4eacb1d8": {
+    "title": "Evaluating Explainable AI: Which Algorithmic Explanations Help Users Predict Model Behavior?",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cf48826b533745eb": {
+    "title": "Human Instruction-Following with Deep Reinforcement Learning via Transfer-Learning from Text",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c2aad946ccdea78f": {
+    "title": "Language Models are Few-Shot Learners",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_aa17774e4a5a1010": {
+    "title": "Aligning Superhuman AI with Human Behavior: Chess as a Model System",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9b11f2b4d3a6a111": {
+    "title": "Open Questions in Creating Safe Open-ended AI: Tensions Between Control and Creativity",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_49d0e9c54598d75f": {
+    "title": "Online Bayesian Goal Inference for Boundedly-Rational Planning Agents",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_dd0b51c92f88f0b8": {
+    "title": "Unsupervised Learning of Visual Features by Contrasting Cluster Assignments",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ddb3aebf3b13c647": {
+    "title": "Quantifying Differences in Reward Functions",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8b3ae15fc7ee249e": {
+    "title": "Compositional Explanations of Neurons",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2aa314412da90693": {
+    "title": "AvE: Assistance via Empowerment",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_274e0974fa7ce720": {
+    "title": "Is SGD a Bayesian sampler? Well, almost",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_99047282a1efb81b": {
+    "title": "GShard: Scaling Giant Models with Conditional Computation and Automatic Sharding",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_012a30b8a005a12c": {
+    "title": "Verifiably Safe Exploration for End-to-End Reinforcement Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8ab49e34de5d3ecd": {
+    "title": "LogiQA: A Challenge Dataset for Machine Reading Comprehension with Logical Reasoning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_75da108fdfb3106e": {
+    "title": "Forecasting AI Progress: A Research Agenda",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_198b1d3db5f95e27": {
+    "title": "Deploying Lifelong Open-Domain Dialogue Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_033334e7f192c5e2": {
+    "title": "Estimating the Brittleness of AI: Safety Integrity Levels and the Need for Testing Out-Of-Distribution Performance",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_004aec5c84faaf31": {
+    "title": "Measurement in AI Policy: Opportunities and Challenges",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e7fd702eb3083e3e": {
+    "title": "Humans learn too: Better Human-AI Interaction using Optimized Human Inputs",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9eb0eb98a9c82939": {
+    "title": "A narrowing of AI research?",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cfa07cf755510e08": {
+    "title": "The Grey Hoodie Project: Big Tobacco, Big Tech, and the threat on academic integrity",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4c2ae2dfba07abf8": {
+    "title": "Safety Aware Reinforcement Learning (SARL)",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_526a6e05602d30c0": {
+    "title": "Robust Imitation Learning from Noisy Demonstrations",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c42b9740e6b4194d": {
+    "title": "Enabling certification of verification-agnostic networks via memory-efficient semidefinite programming",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_30ab055e127baef8": {
+    "title": "Scaling Laws for Autoregressive Generative Modeling",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_02949cb93049b82c": {
+    "title": "Underspecification Presents Challenges for Credibility in Modern Machine Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a1e6c86b13e4cc51": {
+    "title": "Fooling the primate brain with minimal, targeted image manipulation",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8f0ba0c8ecc32b17": {
+    "title": "I Know What You Meant: Learning Human Objectives by (Under)estimating Their Choice Set",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e00f358687aa7aed": {
+    "title": "Avoiding Tampering Incentives in Deep RL via Decoupled Approval",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9fccf5af82caf9b8": {
+    "title": "Imitating Interactive Intelligence",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_36050c782f2880a8": {
+    "title": "Neurosymbolic AI: The 3rd Wave",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7b03a29a7f0a47cb": {
+    "title": "The Challenge of Value Alignment: from Fairer Algorithms to AI Safety",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_54b50aa3fdacde8f": {
+    "title": "Challenges for Using Impact Regularizers to Avoid Negative Side Effects",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e4afc38afe231b0e": {
+    "title": "Scaling Laws for Transfer",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2e8b186e1b754281": {
+    "title": "Rissanen Data Analysis: Examining Dataset Characteristics via Description Length",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_f12247aaa7c5a301": {
+    "title": "Formal Methods for the Informal Engineer: Workshop Recommendations",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_14e5b7d17976f400": {
+    "title": "Adapting Language Models for Zero-shot Learning by Meta-tuning on Dataset and Prompt Collections",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b541b11c1418c27e": {
+    "title": "The Power of Scale for Parameter-Efficient Prompt Tuning",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7461e158ad377f9a": {
+    "title": "True Few-Shot Learning with Language Models",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_88b89589d5046f88": {
+    "title": "Interactive Explanations: Diagnosis and Repair of Reinforcement Learning Based Agent Behaviors",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d4d01f8ca206d12f": {
+    "title": "IQ-Learn: Inverse soft-Q Learning for Imitation",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7a97baccf2d0dfad": {
+    "title": "Evaluating Large Language Models Trained on Code",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_63f483a077d61ed3": {
+    "title": "Scalable Evaluation of Multi-Agent Reinforcement Learning with Melting Pot",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_84ae7baf831ae7f9": {
+    "title": "The Benchmark Lottery",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_80b432979afaa876": {
+    "title": "Human-Level Reinforcement Learning through Theory-Based Modeling, Exploration, and Planning",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2e13a5b9014cb671": {
+    "title": "Evaluating CLIP: Towards Characterization of Broader Capabilities and Downstream Implications",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_ea99c17bfb8dff90": {
+    "title": "What Matters in Learning from Offline Human Demonstrations for Robot Manipulation",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2da411f3489c10cb": {
+    "title": "On the Opportunities and Risks of Foundation Models",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3a5dfe29a457d0e7": {
+    "title": "Program Synthesis with Large Language Models",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_837ba9a1554593f1": {
+    "title": "Finetuned Language Models Are Zero-Shot Learners",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_afea29156eae44db": {
+    "title": "User Tampering in Reinforcement Learning Recommender Systems",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7c0a2d679a7a5ca5": {
+    "title": "Collaborating with Humans without Human Data",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d14b7eb102a079d0": {
+    "title": "Programmatically Interpretable Reinforcement Learning",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_08f395401d44b67d": {
+    "title": "Learning from Untrusted Data",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c6b7c317d780f22b": {
+    "title": "A Learning and Masking Approach to Secure Learning",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a045c0d911610f0a": {
+    "title": "Spatially Transformed Adversarial Examples",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_90af76072fa913d7": {
+    "title": "A Dual Approach to Scalable Verification of Deep Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_21a5d914cfa7094f": {
+    "title": "Iterative Learning with Open-set Noisy Labels",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_96a14c1f19757223": {
+    "title": "Poison Frogs! Targeted Clean-Label Poisoning Attacks on Neural Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_82a90bff040c2d54": {
+    "title": "Reinforcement Learning and Control as Probabilistic Inference: Tutorial and Review",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_16f65dedc5d5f097": {
+    "title": "Constructing Unrestricted Adversarial Examples with Generative Models",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_235c017226022315": {
+    "title": "Robustness May Be at Odds with Accuracy",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_02273093eda16115": {
+    "title": "A Benchmark for Interpretability Methods in Deep Neural Networks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2d7eb828d04a7c93": {
+    "title": "Troubling Trends in Machine Learning Scholarship",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7de0fab79d9a9abb": {
+    "title": "Is Robustness the Cost of Accuracy? -- A Comprehensive Study on the Robustness of 18 Deep Image Classification Models",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_95d1b51c0ecc6684": {
+    "title": "Characterizing Adversarial Examples Based on Spatial Consistency Information for Semantic Segmentation",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_55d2ee5a90362dcc": {
+    "title": "A Closer Look at Deep Policy Gradients",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7e8d35b265d75290": {
+    "title": "Explicability? Legibility? Predictability? Transparency? Privacy? Security? The Emerging Landscape of Interpretable Agent Behavior",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_e61c2ca786a879c2": {
+    "title": "Feature Denoising for Improving Adversarial Robustness",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a7a43764ffb482b6": {
+    "title": "Robust Change Captioning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0701f434e0267fd4": {
+    "title": "Improving Robustness of Machine Translation with Synthetic Noise",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_1d30ff2c0b8a1b22": {
+    "title": "Toybox: A Suite of Environments for Experimental Evaluation of Deep Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_80f6a648f25568e2": {
+    "title": "The Principle of Unchanged Optimality in Reinforcement Learning Generalization",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_eae2467f1f42e114": {
+    "title": "Goal-conditioned Imitation Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d6d4f93f29f8c1e5": {
+    "title": "Behaviour Suite for Reinforcement Learning",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b941110f24a934df": {
+    "title": "LCA: Loss Change Allocation for Neural Network Training",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0cf68bfe04a22e30": {
+    "title": "ReMixMatch: Semi-Supervised Learning with Distribution Alignment and Augmentation Anchoring",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c5965d6b11fab9ce": {
+    "title": "Ask Your Humans: Using Human Instructions to Improve Generalization in Reinforcement Learning",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_abfd963c7afe7589": {
+    "title": "Navigation Turing Test (NTT): Learning to Evaluate Human-Like Navigation",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_393a7a93bd7a4f33": {
+    "title": "Studying Large Language Model Generalization with Influence Functions",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8c46e9a4bb322ee9": {
+    "title": "A Model of Pathways to Artificial Superintelligence Catastrophe for Risk and Decision Analysis",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5cec285678501247": {
+    "title": "Training language models to follow instructions with human feedback",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3625591de24ea616": {
+    "title": "Risks from Learned Optimization  in Advanced Machine Learning Systems",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9daa7dac3bcd0dbc": {
+    "title": "Training a Helpful and Harmless Assistant with Reinforcement Learning from Human Feedback",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e30130fcf4ab2d16": {
+    "title": "Finding Neurons in a Haystack:  Case Studies with Sparse Probing",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5bb7ca04067a7d2f": {
+    "title": "Emergent world representations: Exploring a sequence model trained on a synthetic task",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8bea59ce45262782": {
+    "title": "Towards Automated Circuit Discovery\nfor Mechanistic Interpretability",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_436ef00c5c5fad81": {
+    "title": "A Toy Model of Universality:\nReverse Engineering How Networks Learn Group Operations",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5388c16b3140305d": {
+    "title": "Causal Mediation Analysis for Interpreting Neural NLP:  The Case of Gender Bias",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_cef47b8e28f2ee30": {
+    "title": "Discovering Latent Knowledge in Language Models Without Supervision",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_04ec3ee050cc9518": {
+    "title": "How does GPT-2 compute greater-than?: Interpreting mathematical abilities in a pre-trained language model",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_6ffccb173ea283dc": {
+    "title": "An Interpretability Illusion for BERT",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8030d671c8dc7618": {
+    "title": "Acquisition of Chess Knowledge in AlphaZero",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_96bb7a101a3081a5": {
+    "title": "Toward Transparent AI: A Survey on Interpreting\nthe Inner Structures of Deep Neural Networks\n",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_267f825a372778dc": {
+    "title": "Fixing Weight Decay Regularization in Adam",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4a6c4493fd0d879f": {
+    "title": "Obfuscated Gradients Give a False Sense of Security:\nCircumventing Defenses to Adversarial Examples",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_22c9d63fe77ad418": {
+    "title": "Adversarial Examples for Evaluating Reading Comprehension Systems",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_df26702cd0a432a5": {
+    "title": "Smooth Adversarial Training",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c73d1d24858a5a58": {
+    "title": "Reliable evaluation of adversarial robustness with an ensemble of diverse parameter-free attacks",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_dfe4f6e3d2c81f5f": {
+    "title": "Using Pre-Training Can Improve Model Robustness and Uncertainty",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_613fb830395808b0": {
+    "title": "Towards Evaluating the Robustness \nof Neural Networks",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d17f296dd337d166": {
+    "title": "Adversarial NLI: A New Benchmark \nfor Natural Language Understanding",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b8666a1c7c7a0192": {
+    "title": "A Baseline for Detecting Misclassified and Out-of-Distribution Examples\nin Neural Networks",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7ddf442b31f9baa6": {
+    "title": "ViM: Out-Of-Distribution with Virtual-logit Matching",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a40668486fbcb879": {
+    "title": "A Simple Unified Framework for Detecting Out-of-Distribution Samples and Adversarial Attacks",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_545c495f3af5bccc": {
+    "title": "The Mythos of Model Interpretability",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_784d797528d0ab87": {
+    "title": "Interpretable Explanations of Black Boxes by Meaningful Perturbation",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8a978f212608a025": {
+    "title": "Exemplary natural images explain CNN activations better than feature visualizations\n\n",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_be90c7a8998cd326": {
+    "title": "Network Dissection: \nQuantifying Interpretability of Deep Visual Representations",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9afb76ce70b2f78e": {
+    "title": "Please Stop Explaining Black Box Models for High-Stakes Decisions",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2e751e13428ed9ea": {
+    "title": "Poisoning and Backdooring Contrastive Learning",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ec61370a4d0d45f7": {
+    "title": "Detecting AI Trojans Using Meta Neural Analysis",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4891c64c19a1494c": {
+    "title": "STRIP: A Defence Against Trojan Attacks on Deep Neural Networks",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_681635096b39624d": {
+    "title": "BadNets: Identifying Vulnerabilities in the Machine Learning Model Supply Chain",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_231c1c7eb2d22544": {
+    "title": "Forecasting Future World Events \nwith Neural Networks",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_28dfb02c5189ee73": {
+    "title": "Natural Selection Favors AIs over Humans",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_bd5055688c17e701": {
+    "title": "Towards Measuring the Representation of Subjective Global Opinions in Language Models",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fb06d2ea0e12476b": {
+    "title": "Discovering Language Model Behaviors with Model-Written Evaluations",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4debba2925275e63": {
+    "title": "Constitutional AI: Harmlessness from AI Feedback",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d33fcb4bef6132b8": {
+    "title": "Measuring Progress on Scalable Oversight for Large Language Models",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a1abb2d6195be076": {
+    "title": "Red Teaming Language Models to Reduce Harms: Methods, Scaling Behaviors, and Lessons Learned",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ec04d5adde44eb54": {
+    "title": "Language Models (Mostly) Know What They Know",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_60f689dd4baaa68b": {
+    "title": "Scaling Laws and Interpretability of Learning from Repeated Data",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4efe878bf48a28f3": {
+    "title": "Do the Rewards Justify the Means? Measuring Trade-Offs Between \nRewards and Ethical Behavior in the Machiavelli?Benchmark",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d88381ef1676ad6a": {
+    "title": "Improving Code Generation by Training with Natural Language Feedback",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_dfb9b33fc00b483f": {
+    "title": "Eliciting Latent Predictions from Transformers with the Tuned Lens",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c61fe8a59ccfaa31": {
+    "title": "Pretraining Language Models with Human Preferences",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8160fe2c96d6932f": {
+    "title": "Adversarial Policies Beat Professional-Level Go AIs",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_fc3ac5affbf4fcc3": {
+    "title": "RL with KL penalties is better viewed as Bayesian inference",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_168f4b8a7feb0cd7": {
+    "title": "Reward Reports for Reinforcement Learning",
+    "year": 2022,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_028a9baaa9a77d42": {
+    "title": "A New Formalism, Method and Open Issues for Zero-Shot Coordination",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_468ea22f2d5cf35e": {
+    "title": "Learning to Play Against Any Mixture of Opponents",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_71661b9ac1ac2cae": {
+    "title": "MultiXNet: Multiclass Multistage Multimodal Motion Prediction",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8526802e51962e60": {
+    "title": "Subjectifying Objectivity: Delineating Tastes in Theoretical Quantum Gravity Research",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_42fe28637dfe7730": {
+    "title": "The AGI Containment Problem",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ad8cc8c5ccb611d2": {
+    "title": "Universal adversarial perturbations",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3b0031dba3084f2e": {
+    "title": "Learning to Protect Communications\nwith Adversarial Neural Cryptography",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_066ad11bb2ff28fa": {
+    "title": "Towards Verified Artificial Intelligence",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_9957f33fc4faa835": {
+    "title": "Learning Language Games through Interaction",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_a1cdc1892cbdbd73": {
+    "title": "The Quantization Model of Neural Scaling",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_17ef6ec21f8407a5": {
+    "title": "Universal Adversarial Triggers for Attacking and Analyzing NLP  WARNING: This paper contains model outputs which are offensive in nature.",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5ab982619e6ba5b0": {
+    "title": "Wilds: A Benchmark of in-the-Wild Distribution Shifts",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ecbf833c92b33a47": {
+    "title": "On Single Point Forecasts for Fat-Tailed Variables",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_faac12c9336f2e64": {
+    "title": "Evaluating the Moral Beliefs Encoded in LLMs  Warning: This paper contains moral scenarios which are controversial and offensive in nature.",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c27c6f2ef9ae28b1": {
+    "title": "Inverse Scaling: When Bigger Isn?t Better",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_162b2e1f034993c7": {
+    "title": "Localizing Model Behavior With Path Patching",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_3d78f1acd91ad10a": {
+    "title": "The Capacity for Moral Self-Correction in Large Language Models",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_4f5142e5b00a441f": {
+    "title": "RobustBench: a standardized adversarial robustness benchmark",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_d604aa57800a22e1": {
+    "title": "Visualizing Dynamics: from t-SNE to SEMI-MDPs",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_6d63b24af76850e7": {
+    "title": "Increasing the Interpretability of Recurrent Neural Networks Using Hidden Markov Models",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "common"
+  },
+  "arxiv_709c102c9237b620": {
+    "title": "Unsupervised Risk Estimation Using Only Conditional Independence Structure",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_5488031cfaa2b302": {
+    "title": "Synthesizing the preferred inputs for neurons in neural networks via deep generator networks",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_7fe6d29db39a82b3": {
+    "title": "Bayesian Optimization with Safety Constraints: Safe and Automatic Parameter Tuning in Robotics",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c3043a62c41391ab": {
+    "title": "Practical Black-Box Attacks against Deep Learning Systems  using Adversarial Examples",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c10b9456b03fcc59": {
+    "title": "Graying the black box: Understanding DQNs",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_78174b74c718cad8": {
+    "title": "The Off-Switch Game",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_8c9b4b4fa66e855a": {
+    "title": "Cooperative Inverse Reinforcement Learning",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_e48e7429c48c2e39": {
+    "title": "Generative Adversarial Imitation Learning",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_0b9103d6dc8b3c04": {
+    "title": "Specific versus General Principles for Constitutional AI",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_2a755dc71d8b939c": {
+    "title": "Towards Understanding  Sycophancy in Language Models",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_1051dda54eaf8c38": {
+    "title": "Representation Engineering: A Top-Down Approach to AI Transparency",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_b08e5f64b6d25f47": {
+    "title": "AI Deception: A Survey of Examples, Risks, and Potential Solutions",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_c67778b1627c19d8": {
+    "title": "Codebook Features: Sparse and Discrete Interpretability for Neural Networks",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "arxiv_ca4359c33a477287": {
+    "title": "Vision-Language Models are Zero-Shot  Reward Models for Reinforcement Learning",
+    "year": 2023,
+    "category": "technical_research_breakthrough",
+    "rarity": "rare"
+  },
+  "distill_dd6a446845d57fed": {
+    "title": "A Gentle Introduction to Graph Neural Networks",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_a15bd5a2f0b26e20": {
+    "title": "Adversarial Reprogramming of Neural Cellular Automata",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_46959ccf83a5e89d": {
+    "title": "Weight Banding",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_d2af05099a4301be": {
+    "title": "Branch Specialization",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_8ca56371f32f6a2e": {
+    "title": "Self-Organising Textures",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_e0055470e63b5b83": {
+    "title": "Visualizing Weights",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_63e78aeacd5b3144": {
+    "title": "High-Low Frequency Detectors",
+    "year": 2021,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_e3fcaaea154f7c22": {
+    "title": "Naturally Occurring Equivariance in Neural Networks",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_9025e9a91810edf5": {
+    "title": "Understanding RL Vision",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_dcf03df9a5ecaa60": {
+    "title": "Communicating with Interactive Articles",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_14ddb6790290338e": {
+    "title": "Self-classifying MNIST Digits",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_c5dbee2ef12d51ed": {
+    "title": "Curve Detectors",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_db677f11f1153813": {
+    "title": "Exploring Bayesian Optimization",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_957e47782c32e397": {
+    "title": "An Overview of Early Vision in InceptionV1",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_16bba51135fb54b5": {
+    "title": "Visualizing Neural Networks with the Grand Tour",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_ed5ab808068ad61f": {
+    "title": "Zoom In: An Introduction to Circuits",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_fe09c2226ea40329": {
+    "title": "Growing Neural Cellular Automata",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_67e0be00bc03466d": {
+    "title": "Visualizing the Impact of Feature Attribution Baselines",
+    "year": 2020,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_8ef6f034b4508a82": {
+    "title": "Computing Receptive Fields of Convolutional Neural Networks",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_4dab2fb3c6b0867c": {
+    "title": "A Discussion of 'Adversarial Examples Are Not Bugs, They Are Features'",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_9af84a92d724245f": {
+    "title": "A Discussion of 'Adversarial Examples Are Not Bugs, They Are Features': Adversarial Example Researchers Need to Expand What is Meant by 'Robustness'",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_109a9ad019ae9b2c": {
+    "title": "A Discussion of 'Adversarial Examples Are Not Bugs, They Are Features': Robust Feature Leakage",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_90edb4745db80192": {
+    "title": "A Discussion of 'Adversarial Examples Are Not Bugs, They Are Features': Two Examples of Useful, Non-Robust Features",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_929bb52cf50e0b8d": {
+    "title": "A Discussion of 'Adversarial Examples Are Not Bugs, They Are Features': Adversarially Robust Neural Style Transfer",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_6e90076e03f74714": {
+    "title": "A Discussion of 'Adversarial Examples Are Not Bugs, They Are Features': Adversarial Examples are Just Bugs, Too",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_bda18cad07b62a0d": {
+    "title": "A Discussion of 'Adversarial Examples Are Not Bugs, They Are Features': Discussion and Author Responses",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_a9e837be3cded3d2": {
+    "title": "Open Questions about Generative Adversarial Networks",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_3a645443102ffa1e": {
+    "title": "Activation Atlas",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_eb5c12bc89464f38": {
+    "title": "AI Safety Needs Social Scientists",
+    "year": 2019,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_f2c26f7be5a4bf71": {
+    "title": "Differentiable Image Parameterizations",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_60c80cf91136c14d": {
+    "title": "Feature-wise transformations",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_16581d92f7140bdd": {
+    "title": "The Building Blocks of Interpretability",
+    "year": 2018,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_5445aad20630afcd": {
+    "title": "Sequence Modeling with CTC",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_467d4af00cf674a3": {
+    "title": "Feature Visualization",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_4c8e11a1925e403b": {
+    "title": "Why Momentum Really Works",
+    "year": 2017,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_790f8af19327d105": {
+    "title": "Experiments in Handwriting with a Neural Network",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
+  },
+  "distill_31099860fa969445": {
+    "title": "Attention and Augmented Recurrent Neural Networks",
+    "year": 2016,
+    "category": "technical_research_breakthrough",
+    "rarity": "legendary"
   }
 }

--- a/data/serveable/api/timeline_events/manifest.json
+++ b/data/serveable/api/timeline_events/manifest.json
@@ -1,11 +1,14 @@
 {
   "version": "1.0.0",
   "schema_version": "1.0.0",
-  "generated_at": "2025-11-09T02:12:35.672991Z",
-  "total_events": 28,
+  "generated_at": null,
+  "total_events": 1194,
   "years": [
     2016,
+    2017,
     2018,
+    2019,
+    2020,
     2021,
     2022,
     2023,
@@ -22,6 +25,7 @@
     "all_events": "all_events.json",
     "by_year": "by_year/{year}.json",
     "by_category": "by_category/{category}.json",
-    "index": "event_index.json"
+    "event_index": "event_index.json",
+    "stats": "stats.json"
   }
 }

--- a/data/serveable/api/timeline_events/stats.json
+++ b/data/serveable/api/timeline_events/stats.json
@@ -1,41 +1,47 @@
 {
-  "total_events": 28,
+  "total_events": 1194,
   "by_year": {
-    "2022": 2,
-    "2023": 4,
+    "2016": 54,
+    "2017": 60,
+    "2018": 207,
+    "2019": 200,
+    "2020": 211,
+    "2021": 224,
+    "2022": 192,
+    "2023": 28,
     "2024": 14,
-    "2018": 2,
-    "2021": 1,
-    "2016": 1,
     "2025": 4
   },
   "by_category": {
     "funding_catastrophe": 7,
+    "institutional_decay": 7,
     "organizational_crisis": 6,
-    "technical_research_breakthrough": 8,
-    "institutional_decay": 7
+    "technical_research_breakthrough": 1174
   },
   "by_rarity": {
-    "rare": 4,
-    "common": 20,
-    "legendary": 4
+    "common": 77,
+    "legendary": 41,
+    "rare": 1076
   },
   "impact_variables": {
-    "cash": 15,
-    "reputation": 15,
-    "research": 21,
-    "papers": 10,
-    "stress": 13,
     "burnout_risk": 5,
-    "vibey_doom": 27,
-    "technical_debt": 12,
+    "cash": 15,
+    "ethics_risk": 16,
     "media_reputation": 4,
-    "ethics_risk": 16
+    "papers": 1176,
+    "reputation": 15,
+    "research": 1187,
+    "stress": 13,
+    "technical_debt": 12,
+    "vibey_doom": 1193
   },
   "pdoom_impact_distribution": {
-    "null": 21,
-    "negative": 0,
-    "zero": 0,
-    "positive": 7
+    "10": 1,
+    "4": 1,
+    "5": 1,
+    "6": 2,
+    "7": 1,
+    "8": 1,
+    "None": 1187
   }
 }

--- a/scripts/build/project_timeline_events.py
+++ b/scripts/build/project_timeline_events.py
@@ -250,6 +250,89 @@ def render(records, hand_authored, provenance):
     return payload, lineage
 
 
+def render_sidecars(records):
+    """manifest.json, stats.json and event_index.json, derived from the feed.
+
+    These three sat at 28 records while all_events.json held 1,194, from
+    2025-11-09 to 2026-08-10 -- nine months of a published catalogue describing
+    2.3% of the collection it catalogues. check_invariants.py knew, printed all
+    three as KNOWN divergences, and passed, because they had no producer and
+    there was nothing to compare them against. That is the whole of
+    pdoom-data#52 and it is the reason this function exists rather than a patch
+    to the numbers.
+
+    The key sets are preserved EXACTLY. A consumer reading manifest.json today
+    gets the same shape tomorrow with true values in it; nothing is added and
+    nothing is removed, because widening a published file is a consumer
+    decision and this is a correctness fix.
+
+    generated_at becomes null, deliberately. It read 2025-11-09 -- a stamp that
+    was true once and had been false for nine months, which is exactly the
+    fabricated-clock failure this repo forbids. A fresh wall-clock stamp is the
+    alternative and it would make --check non-deterministic, which this producer
+    already refuses for the feed itself. null is ungated and honest; freshness
+    belongs to LINEAGE.json and to the rebuild check.
+
+    What these numbers now show, and it is not flattering: by_rarity is 1,076
+    'rare' out of 1,194, and by_category is 1,174 'technical_research_breakthrough'
+    out of 1,194. Both are artefacts of the bulk arXiv import rather than
+    editorial judgement -- pdoom-data#51 records that rarity is a length
+    threshold on a discarded field. Publishing the true distribution makes that
+    visible in a served file instead of only in an issue.
+    """
+    years = sorted(set(r["year"] for r in records.values()))
+    categories = sorted(set(r["category"] for r in records.values()))
+
+    def tally(field):
+        out = {}
+        for r in records.values():
+            out[str(r[field])] = out.get(str(r[field]), 0) + 1
+        return dict(sorted(out.items()))
+
+    impact_variables = {}
+    pdoom_distribution = {}
+    for r in records.values():
+        for impact in r.get("impacts", []):
+            name = impact.get("variable") if isinstance(impact, dict) else None
+            if name:
+                impact_variables[name] = impact_variables.get(name, 0) + 1
+        key = str(r.get("pdoom_impact"))
+        pdoom_distribution[key] = pdoom_distribution.get(key, 0) + 1
+
+    manifest = {
+        "version": "1.0.0",
+        "schema_version": "1.0.0",
+        "generated_at": None,
+        "total_events": len(records),
+        "years": years,
+        "categories": categories,
+        "files": {
+            "all_events": "all_events.json",
+            "by_year": "by_year/{year}.json",
+            "by_category": "by_category/{category}.json",
+            "event_index": "event_index.json",
+            "stats": "stats.json",
+        },
+    }
+    stats = {
+        "total_events": len(records),
+        "by_year": tally("year"),
+        "by_category": tally("category"),
+        "by_rarity": tally("rarity"),
+        "impact_variables": dict(sorted(impact_variables.items())),
+        "pdoom_impact_distribution": dict(sorted(pdoom_distribution.items())),
+    }
+    index = dict(
+        (rid, {
+            "title": r["title"],
+            "year": r["year"],
+            "category": r["category"],
+            "rarity": r["rarity"],
+        })
+        for rid, r in records.items())
+    return manifest, stats, index
+
+
 def write_json(path, obj):
     """Write via temp + os.replace.
 
@@ -289,6 +372,11 @@ def main():
     feed_path = os.path.join(OUT_DIR, "all_events.json")
     lineage_path = os.path.join(OUT_DIR, "LINEAGE.json")
 
+    manifest, stats, index = render_sidecars(records)
+    sidecars = [("manifest.json", manifest), ("stats.json", stats),
+                ("event_index.json", index)]
+    print("  sidecars          : %d, all derived from the feed" % len(sidecars))
+
     if args.check or args.diff:
         if not os.path.isfile(feed_path):
             print("CHECK FAILED: %s does not exist" % feed_path)
@@ -315,13 +403,28 @@ def main():
             if load(lineage_path) != lineage:
                 print("CHECK FAILED: committed LINEAGE differs from a fresh build.")
                 return 1
-        print("CHECK OK: committed output matches a fresh build")
+        for name, fresh in sidecars:
+            path = os.path.join(OUT_DIR, name)
+            if not os.path.isfile(path):
+                print("CHECK FAILED: %s does not exist" % name)
+                return 1
+            if load(path) != fresh:
+                print("CHECK FAILED: %s differs from a fresh build. This is the "
+                      "check that did not exist while it claimed 28 of 1,194 "
+                      "records for nine months (pdoom-data#52)." % name)
+                return 1
+        print("CHECK OK: committed output matches a fresh build "
+              "(feed, lineage and %d sidecars)" % len(sidecars))
         return 0
 
     write_json(feed_path, payload)
     write_json(lineage_path, lineage)
     print("wrote %s" % os.path.relpath(feed_path, REPO_ROOT).replace("\\", "/"))
     print("wrote %s" % os.path.relpath(lineage_path, REPO_ROOT).replace("\\", "/"))
+    for name, fresh in sidecars:
+        write_json(os.path.join(OUT_DIR, name), fresh)
+        print("wrote %s" % os.path.relpath(
+            os.path.join(OUT_DIR, name), REPO_ROOT).replace("\\", "/"))
     return 0
 
 

--- a/scripts/validation/check_all.py
+++ b/scripts/validation/check_all.py
@@ -44,6 +44,14 @@ REBUILD = [
     ("candidates rebuild is byte-identical", ["scripts/build/project_candidates.py", "--check"], True),
     ("frontier_labs rebuild is byte-identical", ["scripts/build/project_frontier_labs.py", "--check"], True),
     ("reviewed rebuild is byte-identical", ["scripts/build/project_reviewed.py", "--check"], True),
+    # Both of these ran in data-integrity.yml and NOT here, so "run check_all.py
+    # and nothing else" was false for two of the five projections -- including
+    # the one that guards the timeline_events sidecars. Found 2026-08-10 while
+    # giving those sidecars a producer. A single entry point that covers most of
+    # the checks is the same defect class as a catalogue that describes most of
+    # its collection.
+    ("timeline_events rebuild is byte-identical", ["scripts/build/project_timeline_events.py", "--check"], True),
+    ("taxonomy rebuild is byte-identical", ["scripts/build/project_taxonomy.py", "--check"], True),
 ]
 
 REPORTING = [

--- a/scripts/validation/check_invariants.py
+++ b/scripts/validation/check_invariants.py
@@ -251,16 +251,26 @@ def check_landmine_guarded():
 # exists so the check can be turned on TODAY, catching any NEW drift, without
 # a pre-existing problem blocking every build until it is fixed. Delete an
 # entry when its issue closes -- and the check will then start enforcing it.
-KNOWN_COUNT_DIVERGENCES = {
-    "data/serveable/api/timeline_events/manifest.json": (
-        "reports 28 events, generated 2025-11-09, while all_events.json holds "
-        "1194. Stale by 1166 records. Tracked in #52."),
-    "data/serveable/api/timeline_events/stats.json": (
-        "reports total_events 28 with a by_rarity breakdown of the original "
-        "hand-authored set. Stale by 1166 records. Tracked in #52."),
-    "data/serveable/api/timeline_events/event_index.json": (
-        "indexes 28 of 1194 records. Tracked in #52."),
-}
+# EMPTIED 2026-08-10, and kept as an empty dict rather than deleted, because the
+# mechanism is still the right one and the next divergence should have to be
+# declared here in a commit rather than discovered in production.
+#
+# It held three entries for nine months: manifest.json, stats.json and
+# event_index.json each claiming 28 records against all_events.json's 1,194.
+# Every one was true, documented, printed on every run, and passing.
+#
+# That is the shape Workshop 2 named as its own class 5, the KNOWING ALLOWLIST:
+# a check that sees the defect perfectly and is configured to permit it. It
+# defeats every remedy the estate proposed that week -- arming it does nothing
+# because it is armed, re-aiming does nothing because it is aimed correctly, a
+# freshness window does nothing because it is current. The check was never
+# fooled. The reader was, by its exit code.
+#
+# The three files now have a producer (project_timeline_events.py builds them
+# from the feed, and --check asserts byte-identity), so the entries are removed
+# rather than updated. An entry added here should carry a return date, or it
+# becomes what these were.
+KNOWN_COUNT_DIVERGENCES = {}
 
 
 def check_timeline_event_counts():


### PR DESCRIPTION
fix: give the three timeline_events sidecars a producer, and empty the allowlist that permitted them

Closes pdoom-data#52. manifest.json, stats.json and event_index.json each
claimed 28 records while all_events.json held 1,194 -- a published catalogue
describing 2.3% of the collection it catalogues, from 2025-11-09 to today.

They are now built from the feed by project_timeline_events.py and --check
asserts byte-identity, so the divergence cannot recur silently. Proven the way
this repo now requires: the new check FAILS against the committed stale files
before the build and passes after it.

Key sets are preserved exactly. Nothing added, nothing removed -- widening a
published file is a consumer decision and this is a correctness fix.

generated_at becomes null rather than a fresh stamp. It read 2025-11-09, true
once and false for nine months, which is the fabricated-clock failure this repo
forbids; and a live stamp would make --check non-deterministic, which this
producer already refuses for the feed. Freshness belongs to LINEAGE and to the
rebuild check.

check_invariants.py's KNOWN_COUNT_DIVERGENCES is emptied. It held these three
for nine months: true, documented, printed on every run, and passing. That is
Workshop 2's class 5, the knowing allowlist -- a check that sees the defect
perfectly and is configured to permit it, which defeats every other remedy the
estate proposed that week. The dict is kept, empty, so the next divergence has
to be declared in a commit rather than discovered in production.

Two numbers this now publishes, and they are not flattering: by_rarity is 1,076
'rare' of 1,194 and by_category is 1,174 'technical_research_breakthrough' of
1,194. Both are artefacts of the bulk import rather than editorial judgement --
pdoom-data#51 records that rarity is a length threshold on a discarded field.
Publishing the true distribution makes that visible in a served file instead of
only in an issue.

Also: check_all.py was missing the timeline_events and taxonomy rebuild checks
that data-integrity.yml runs, so "run this and nothing else" was false for two
of the five projections -- including the one guarding these sidecars.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
